### PR TITLE
cache org.eclipse.core.runtime.Plugin.getStateLocation()

### DIFF
--- a/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Plugin.java
+++ b/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Plugin.java
@@ -128,6 +128,8 @@ public abstract class Plugin implements BundleActivator {
 	 */
 	private Bundle bundle;
 
+	private volatile IPath stateLocation;
+
 	/**
 	 * The debug flag for this plug-in.  The flag is false by default.
 	 * This flag is only used when the DebugOptions service is not available.
@@ -256,7 +258,12 @@ public abstract class Plugin implements BundleActivator {
 	 *  XXX Investigate the usage of a service factory (see also platform.getStateLocation)
 	 */
 	public final IPath getStateLocation() throws IllegalStateException {
-		return InternalPlatform.getDefault().getStateLocation(getBundle(), true);
+		if (stateLocation == null) {
+			// cache the value to avoid repeated java.io.File.mkdirs()
+			// does not matter if the value is computed twice in parallel
+			stateLocation = InternalPlatform.getDefault().getStateLocation(getBundle(), true);
+		}
+		return stateLocation;
 	}
 
 	/**


### PR DESCRIPTION
To avoid repeated java.io.File.mkdirs() I/O which should create the
directory only once anyway and just costly checks if folder exists with
costly I/O again and again.

It's called many times in a row during startup. Especially from
org.eclipse.pde.core, org.eclipse.jdt.core

most calls from 
```
	org.eclipse.core.internal.runtime.InternalPlatform.getStateLocation(org.osgi.framework.Bundle, boolean) line: 471	
	org.eclipse.pde.internal.core.PDECore(org.eclipse.core.runtime.Plugin).getStateLocation() line: 259	
	org.eclipse.pde.internal.core.ExternalLibraryCache.getLibraryCacheDir() line: 251	
	org.eclipse.pde.internal.core.ExternalLibraryCache.getExtractedLibraries(org.eclipse.pde.core.plugin.IPluginModelBase) line: 125	
	org.eclipse.pde.internal.core.ExternalModelManager.getExtractedLibraries(org.eclipse.pde.core.plugin.IPluginModelBase) line: 57	
	org.eclipse.pde.internal.core.PDEClasspathContainer.addExternalPlugin(org.eclipse.pde.core.plugin.IPluginModelBase, org.eclipse.pde.internal.core.PDEClasspathContainer.Rule[], java.util.ArrayList<org.eclipse.jdt.core.IClasspathEntry>) line: 87	
	org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer.addPlugin(org.eclipse.osgi.service.resolver.BundleDescription, boolean, java.util.Map<org.eclipse.osgi.service.resolver.BundleDescription,java.util.ArrayList<org.eclipse.pde.internal.core.PDEClasspathContainer.Rule>>, java.util.ArrayList<org.eclipse.jdt.core.IClasspathEntry>) line: 352	
	org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer.addDependency(org.eclipse.osgi.service.resolver.BundleDescription, java.util.HashSet<org.eclipse.osgi.service.resolver.BundleDescription>, java.util.Map<org.eclipse.osgi.service.resolver.BundleDescription,java.util.ArrayList<org.eclipse.pde.internal.core.PDEClasspathContainer.Rule>>, java.util.ArrayList<org.eclipse.jdt.core.IClasspathEntry>, boolean) line: 297	
	org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer.addDependency(org.eclipse.osgi.service.resolver.BundleDescription, java.util.HashSet<org.eclipse.osgi.service.resolver.BundleDescription>, java.util.Map<org.eclipse.osgi.service.resolver.BundleDescription,java.util.ArrayList<org.eclipse.pde.internal.core.PDEClasspathContainer.Rule>>, java.util.ArrayList<org.eclipse.jdt.core.IClasspathEntry>, boolean) line: 309	
	org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer.addDependency(org.eclipse.osgi.service.resolver.BundleDescription, java.util.HashSet<org.eclipse.osgi.service.resolver.BundleDescription>, java.util.Map<org.eclipse.osgi.service.resolver.BundleDescription,java.util.ArrayList<org.eclipse.pde.internal.core.PDEClasspathContainer.Rule>>, java.util.ArrayList<org.eclipse.jdt.core.IClasspathEntry>, boolean) line: 309	
	org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer.addDependency(org.eclipse.osgi.service.resolver.BundleDescription, java.util.HashSet<org.eclipse.osgi.service.resolver.BundleDescription>, java.util.Map<org.eclipse.osgi.service.resolver.BundleDescription,java.util.ArrayList<org.eclipse.pde.internal.core.PDEClasspathContainer.Rule>>, java.util.ArrayList<org.eclipse.jdt.core.IClasspathEntry>) line: 280	
	org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer.computePluginEntries() line: 162	
	org.eclipse.pde.internal.core.RequiredPluginsClasspathContainer.getClasspathEntries() line: 112	
	org.eclipse.jdt.internal.core.JavaProject.resolveClasspath(org.eclipse.jdt.core.IClasspathEntry[], org.eclipse.jdt.core.IClasspathEntry[], boolean, boolean) line: 3246	
	org.eclipse.jdt.internal.core.JavaProject.resolveClasspath(org.eclipse.jdt.internal.core.JavaModelManager$PerProjectInfo, boolean, boolean) line: 3404	
	org.eclipse.jdt.internal.core.ClasspathChange.generateDelta(org.eclipse.jdt.internal.core.JavaElementDelta, boolean) line: 243	
	org.eclipse.jdt.internal.core.DeltaProcessor.resourceChanged(org.eclipse.core.resources.IResourceChangeEvent) line: 2127	
	org.eclipse.jdt.internal.core.DeltaProcessingState.resourceChanged(org.eclipse.core.resources.IResourceChangeEvent) line: 501	
	org.eclipse.core.internal.events.NotificationManager$1.run() line: 305	
	org.eclipse.core.runtime.SafeRunner.run(org.eclipse.core.runtime.ISafeRunnable) line: 45	
	org.eclipse.core.internal.events.NotificationManager.notify(org.eclipse.core.internal.events.ResourceChangeListenerList$ListenerEntry[], org.eclipse.core.internal.events.ResourceChangeEvent, boolean) line: 295	
	org.eclipse.core.internal.events.NotificationManager.broadcastChanges(org.eclipse.core.internal.watson.ElementTree, org.eclipse.core.internal.events.ResourceChangeEvent, boolean) line: 158	
	org.eclipse.core.internal.resources.Workspace.broadcastPostChange() line: 381	
	org.eclipse.core.internal.resources.Workspace.endOperation(org.eclipse.core.runtime.jobs.ISchedulingRule, boolean) line: 1505	
	org.eclipse.core.internal.resources.Workspace.run(org.eclipse.core.runtime.ICoreRunnable, org.eclipse.core.runtime.jobs.ISchedulingRule, int, org.eclipse.core.runtime.IProgressMonitor) line: 2329	
	org.eclipse.core.internal.events.NotificationManager$NotifyJob.run(org.eclipse.core.runtime.IProgressMonitor) line: 44	
	org.eclipse.core.internal.jobs.Worker.run() line: 63	

```