### PR TITLE
Bug 543660 - JobGroup.join() blocks if scheduling more jobs as seed count

### DIFF
--- a/bundles/org.eclipse.core.jobs/src/org/eclipse/core/runtime/jobs/JobGroup.java
+++ b/bundles/org.eclipse.core.jobs/src/org/eclipse/core/runtime/jobs/JobGroup.java
@@ -86,12 +86,24 @@ public class JobGroup extends InternalJobGroup {
 	 * @param seedJobsCount the initial number of jobs that will be added to the job group.
 	 * This is the initial count of jobs with which the creator of the job group will "seed"
 	 * the job group. Those initial jobs may discover more work and add yet more jobs, but
-	 * those additional jobs should not be included in this initial "seed" count. If this
-	 * value is set too high, the job group will never transition to the done ({@link #NONE})
+	 * those additional jobs should not be included in this initial "seed" count. 
+	 * <ul>
+	 * <li>
+	 * If this value is set too high (higher than the number of actually scheduled jobs), 
+	 * the job group will never transition to the done ({@link #NONE})
 	 * state, {@link #join(long, IProgressMonitor)} calls will hang, and {@link #getResult()}
-	 * calls will return invalid results. If this value is set too low, the job group may
+	 * calls will return invalid results. 
+	 * </li>
+	 * <li>
+	 * If this value is set too low, the job group may
 	 * transition to the ({@link #NONE}) state before all of the jobs have been scheduled,
 	 * causing a {@link #join(long, IProgressMonitor)} call to return too early.
+	 * </li>
+	 * <li>Scheduling more jobs to the group after {@code seedJobsCount} previously 
+	 * scheduled jobs were finished may cause a {@link #join(long, IProgressMonitor)} 
+	 * call to return too early.
+	 * </li>
+	 * </ul>
 	 */
 	public JobGroup(String name, int maxThreads, int seedJobsCount) {
 		super(name, maxThreads, seedJobsCount);


### PR DESCRIPTION
endJobGroup() should not unconditionally reset the
seedJobsRemainingCount to seedJobsCount. In case seedJobsCount > 1, and
we schedule only one more job, join() on the group will block forever,
waiting for the seedJobsCount to become zero.

Also jobGroup results should be preserved if new jobs are scheduled on
the group where previously scheduled jobs already finished with non-zero
results.