### PR TITLE
fix Multithreaded access to TestBarrier.myStatus[i]

### DIFF
--- a/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/LockManager.java
+++ b/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/LockManager.java
@@ -67,7 +67,7 @@ public class LockManager {
 	}
 
 	//the lock listener for this lock manager
-	protected LockListener lockListener;
+	protected volatile LockListener lockListener;
 	/*
 	 * The internal data structure that stores all the relationships
 	 * between the locks (or rules) and the threads that own them.

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AsynchTestJob.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/AsynchTestJob.java
@@ -13,19 +13,20 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.tests.harness.TestBarrier;
+import org.eclipse.core.tests.harness.TestBarrier2;
 
 /**
  * A job that executes asynchronously on a separate thread
  */
 class AsynchTestJob extends Job {
-	private int[] status;
+	private AtomicIntegerArray status;
 	private int index;
 
-	public AsynchTestJob(String name, int[] status, int index) {
+	public AsynchTestJob(String name, AtomicIntegerArray status, int index) {
 		super(name);
 		this.status = status;
 		this.index = index;
@@ -33,11 +34,11 @@ class AsynchTestJob extends Job {
 
 	@Override
 	public IStatus run(IProgressMonitor monitor) {
-		status[index] = TestBarrier.STATUS_RUNNING;
+		status.set(index, TestBarrier2.STATUS_RUNNING);
 		AsynchExecThread t = new AsynchExecThread(monitor, this, 100, 10, getName(), status, index);
-		TestBarrier.waitForStatus(status, index, TestBarrier.STATUS_START);
+		TestBarrier2.waitForStatus(status, index, TestBarrier2.STATUS_START);
 		t.start();
-		status[index] = TestBarrier.STATUS_WAIT_FOR_START;
+		status.set(index, TestBarrier2.STATUS_WAIT_FOR_START);
 		return Job.ASYNC_FINISH;
 	}
 

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_129551.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_129551.java
@@ -14,7 +14,7 @@
 package org.eclipse.core.tests.runtime.jobs;
 
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
-import org.eclipse.core.tests.harness.TestBarrier;
+import org.eclipse.core.tests.harness.TestBarrier2;
 import org.eclipse.core.tests.harness.TestJob;
 
 /**
@@ -25,7 +25,7 @@ import org.eclipse.core.tests.harness.TestJob;
  */
 public class Bug_129551 extends AbstractJobManagerTest {
 	final boolean[] shouldSleep = new boolean[] {true};
-	TestBarrier barrier = new TestBarrier();
+	TestBarrier2 barrier = new TestBarrier2();
 	RuntimeException[] failure = new RuntimeException[1];
 
 	class BugJob extends TestJob {
@@ -39,16 +39,16 @@ public class Bug_129551 extends AbstractJobManagerTest {
 			if (!shouldSleep[0]) {
 				return true;
 			}
-			barrier.setStatus(TestBarrier.STATUS_RUNNING);
+			barrier.setStatus(TestBarrier2.STATUS_RUNNING);
 			//wait for blocking jobs to queue up
-			barrier.waitForStatus(TestBarrier.STATUS_START);
+			barrier.waitForStatus(TestBarrier2.STATUS_START);
 			//put the job to sleep
 			try {
 				this.sleep();
 			} catch (RuntimeException e) {
 				failure[0] = e;
 			}
-			barrier.setStatus(TestBarrier.STATUS_DONE);
+			barrier.setStatus(TestBarrier2.STATUS_DONE);
 			return true;
 		}
 	}
@@ -70,7 +70,7 @@ public class Bug_129551 extends AbstractJobManagerTest {
 		job.schedule();
 		other.schedule();
 		//wait until the first job is about to run
-		barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 		//wait to ensure the other job is blocked
 		try {
 			Thread.sleep(1000);
@@ -78,8 +78,8 @@ public class Bug_129551 extends AbstractJobManagerTest {
 			fail("4.99", e);
 		}
 		//let the first job go
-		barrier.setStatus(TestBarrier.STATUS_START);
-		barrier.waitForStatus(TestBarrier.STATUS_DONE);
+		barrier.setStatus(TestBarrier2.STATUS_START);
+		barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 
 		//check for failure
 		if (failure[0] != null) {

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_307282.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_307282.java
@@ -15,7 +15,7 @@ package org.eclipse.core.tests.runtime.jobs;
 
 import org.eclipse.core.runtime.jobs.ILock;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.tests.harness.TestBarrier;
+import org.eclipse.core.tests.harness.TestBarrier2;
 
 /**
  * Regression test for bug 307282
@@ -41,8 +41,8 @@ public class Bug_307282 extends AbstractJobManagerTest {
 		final ILock lock1 = Job.getJobManager().newLock();
 		final ILock lock2 = Job.getJobManager().newLock();
 
-		final TestBarrier tb1 = new TestBarrier(-1);
-		final TestBarrier tb2 = new TestBarrier(-1);
+		final TestBarrier2 tb1 = new TestBarrier2(-1);
+		final TestBarrier2 tb2 = new TestBarrier2(-1);
 
 		final int INTERRUPTED = 1000;
 		final int RELEASE_LOCK = 10001;
@@ -52,14 +52,14 @@ public class Bug_307282 extends AbstractJobManagerTest {
 			public void run() {
 				lock1.acquire();
 
-				tb1.setStatus(TestBarrier.STATUS_WAIT_FOR_START);
-				tb1.waitForStatus(TestBarrier.STATUS_START);
+				tb1.setStatus(TestBarrier2.STATUS_WAIT_FOR_START);
+				tb1.waitForStatus(TestBarrier2.STATUS_START);
 
 				tb1.waitForStatus(RELEASE_LOCK);
 				lock1.release();
 
-				tb1.waitForStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
-				tb1.setStatus(TestBarrier.STATUS_DONE);
+				tb1.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
+				tb1.setStatus(TestBarrier2.STATUS_DONE);
 			}
 		};
 
@@ -68,8 +68,8 @@ public class Bug_307282 extends AbstractJobManagerTest {
 			public void run() {
 				lock2.acquire();
 
-				tb2.setStatus(TestBarrier.STATUS_WAIT_FOR_START);
-				tb2.waitForStatus(TestBarrier.STATUS_START);
+				tb2.setStatus(TestBarrier2.STATUS_WAIT_FOR_START);
+				tb2.waitForStatus(TestBarrier2.STATUS_START);
 
 				// Now attempt acquire lock1 with an integer delay
 				try {
@@ -81,8 +81,8 @@ public class Bug_307282 extends AbstractJobManagerTest {
 				tb2.waitForStatus(RELEASE_LOCK);
 				lock2.release();
 
-				tb2.waitForStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
-				tb2.setStatus(TestBarrier.STATUS_DONE);
+				tb2.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
+				tb2.setStatus(TestBarrier2.STATUS_DONE);
 			}
 		};
 
@@ -91,11 +91,11 @@ public class Bug_307282 extends AbstractJobManagerTest {
 		t2.start();
 
 		// wait for the threads to get to start and acquire first lock
-		tb1.waitForStatus(TestBarrier.STATUS_WAIT_FOR_START);
-		tb2.waitForStatus(TestBarrier.STATUS_WAIT_FOR_START);
+		tb1.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_START);
+		tb2.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_START);
 		// now let thread 2 attempt to acquire lock 2
-		tb1.setStatus(TestBarrier.STATUS_START);
-		tb2.setStatus(TestBarrier.STATUS_START);
+		tb1.setStatus(TestBarrier2.STATUS_START);
+		tb2.setStatus(TestBarrier2.STATUS_START);
 		Thread.sleep(1000); // not-so-small sleep so thread 2 is definitely in the acquire
 
 		// Interrupt thread 2 while it's waiting for lock1
@@ -113,9 +113,9 @@ public class Bug_307282 extends AbstractJobManagerTest {
 		tb2.setStatus(RELEASE_LOCK);
 		assertTrue(lock2.acquire(1000));
 
-		tb1.setStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
-		tb2.setStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
-		tb1.waitForStatus(TestBarrier.STATUS_DONE);
-		tb2.waitForStatus(TestBarrier.STATUS_DONE);
+		tb1.setStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
+		tb2.setStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
+		tb1.waitForStatus(TestBarrier2.STATUS_DONE);
+		tb2.waitForStatus(TestBarrier2.STATUS_DONE);
 	}
 }

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_307391.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_307391.java
@@ -15,7 +15,7 @@ package org.eclipse.core.tests.runtime.jobs;
 
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.tests.harness.TestBarrier;
+import org.eclipse.core.tests.harness.TestBarrier2;
 
 /**
  * Regression test for bug 307391
@@ -38,8 +38,8 @@ public class Bug_307391 extends AbstractJobManagerTest {
 	public void testYieldWithlockAcquire() throws Exception {
 		final IdentityRule idSchedRule = new IdentityRule();
 
-		final TestBarrier tb1 = new TestBarrier(-1);
-		final TestBarrier tb2 = new TestBarrier(-1);
+		final TestBarrier2 tb1 = new TestBarrier2(-1);
+		final TestBarrier2 tb2 = new TestBarrier2(-1);
 
 		final int YIELD2 = 10002;
 		final int ACQUIRE2 = 1005;
@@ -51,8 +51,8 @@ public class Bug_307391 extends AbstractJobManagerTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				Job.getJobManager().beginRule(idSchedRule, null);
 
-				tb1.setStatus(TestBarrier.STATUS_WAIT_FOR_START);
-				tb1.waitForStatus(TestBarrier.STATUS_START);
+				tb1.setStatus(TestBarrier2.STATUS_WAIT_FOR_START);
+				tb1.waitForStatus(TestBarrier2.STATUS_START);
 
 				// Yield our rule
 				Job.getJobManager().currentJob().yieldRule(null);
@@ -64,7 +64,7 @@ public class Bug_307391 extends AbstractJobManagerTest {
 
 				// The test executed successfully
 				Job.getJobManager().endRule(idSchedRule);
-				tb1.setStatus(TestBarrier.STATUS_DONE);
+				tb1.setStatus(TestBarrier2.STATUS_DONE);
 				return Status.OK_STATUS;
 			}
 		};
@@ -72,8 +72,8 @@ public class Bug_307391 extends AbstractJobManagerTest {
 		Thread t2 = new Thread() {
 			@Override
 			public void run() {
-				tb2.setStatus(TestBarrier.STATUS_WAIT_FOR_START);
-				tb2.waitForStatus(TestBarrier.STATUS_START);
+				tb2.setStatus(TestBarrier2.STATUS_WAIT_FOR_START);
+				tb2.waitForStatus(TestBarrier2.STATUS_START);
 
 				Job.getJobManager().beginRule(idSchedRule, null);
 				Job.getJobManager().endRule(idSchedRule);
@@ -83,7 +83,7 @@ public class Bug_307391 extends AbstractJobManagerTest {
 				Job.getJobManager().endRule(idSchedRule);
 
 				// that all went well, signal we've passed
-				tb2.setStatus(TestBarrier.STATUS_DONE);
+				tb2.setStatus(TestBarrier2.STATUS_DONE);
 			}
 		};
 
@@ -92,13 +92,13 @@ public class Bug_307391 extends AbstractJobManagerTest {
 		t2.start();
 
 		// wait for the threads to get to start and acquire sched rules
-		tb1.waitForStatus(TestBarrier.STATUS_WAIT_FOR_START);
-		tb2.waitForStatus(TestBarrier.STATUS_WAIT_FOR_START);
+		tb1.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_START);
+		tb2.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_START);
 
 		// first acquire and yield
-		tb2.setStatus(TestBarrier.STATUS_START);
+		tb2.setStatus(TestBarrier2.STATUS_START);
 		Thread.sleep(1000);
-		tb1.setStatus(TestBarrier.STATUS_START);
+		tb1.setStatus(TestBarrier2.STATUS_START);
 
 		// second acquire and yield
 		tb2.setStatus(ACQUIRE2);
@@ -106,7 +106,7 @@ public class Bug_307391 extends AbstractJobManagerTest {
 		tb1.setStatus(YIELD2);
 
 		// Wait for them to finish
-		tb1.waitForStatus(TestBarrier.STATUS_DONE);
-		tb2.waitForStatus(TestBarrier.STATUS_DONE);
+		tb1.waitForStatus(TestBarrier2.STATUS_DONE);
+		tb2.waitForStatus(TestBarrier2.STATUS_DONE);
 	}
 }

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_311756.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_311756.java
@@ -15,7 +15,7 @@ package org.eclipse.core.tests.runtime.jobs;
 
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.tests.harness.TestBarrier;
+import org.eclipse.core.tests.harness.TestBarrier2;
 
 /**
  * Make sure that IProgressMonitor's blocked/unblocked is invoked.
@@ -46,12 +46,12 @@ public class Bug_311756 extends AbstractJobManagerTest {
 					blocked[0] = CLEARED;
 			}
 		};
-		final TestBarrier barrier = new TestBarrier(TestBarrier.STATUS_START);
+		final TestBarrier2 barrier = new TestBarrier2(TestBarrier2.STATUS_START);
 		IdentityRule rule = new IdentityRule();
 		Job conflicting = new Job("Conflicting") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				barrier.setStatus(TestBarrier.STATUS_RUNNING);
+				barrier.setStatus(TestBarrier2.STATUS_RUNNING);
 				try {
 					Thread.sleep(1000);
 				} catch (InterruptedException e) {
@@ -63,7 +63,7 @@ public class Bug_311756 extends AbstractJobManagerTest {
 		conflicting.setRule(rule);
 		conflicting.schedule();
 
-		barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 		try {
 			Job.getJobManager().beginRule(rule, wrapper);
 		} finally {
@@ -92,14 +92,14 @@ public class Bug_311756 extends AbstractJobManagerTest {
 					blocked[0] = CLEARED;
 			}
 		};
-		final TestBarrier barrier = new TestBarrier(TestBarrier.STATUS_START);
+		final TestBarrier2 barrier = new TestBarrier2(TestBarrier2.STATUS_START);
 		final IdentityRule rule = new IdentityRule();
 		final Thread[] destinationThread = new Thread[1];
 		Job conflicting = new Job("Conflicting") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				barrier.setStatus(TestBarrier.STATUS_RUNNING);
-				barrier.waitForStatus(TestBarrier.STATUS_BLOCKED);
+				barrier.setStatus(TestBarrier2.STATUS_RUNNING);
+				barrier.waitForStatus(TestBarrier2.STATUS_BLOCKED);
 				try {
 					Thread.sleep(100);
 				} catch (InterruptedException e) {
@@ -113,7 +113,7 @@ public class Bug_311756 extends AbstractJobManagerTest {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				destinationThread[0] = getThread();
-				barrier.setStatus(TestBarrier.STATUS_BLOCKED);
+				barrier.setStatus(TestBarrier2.STATUS_BLOCKED);
 				getJobManager().beginRule(rule, wrapper);
 				getJobManager().endRule(rule);
 				return Status.OK_STATUS;
@@ -121,7 +121,7 @@ public class Bug_311756 extends AbstractJobManagerTest {
 		};
 		conflicting.setRule(rule);
 		conflicting.schedule();
-		barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 		transferTo.schedule();
 		waitForCompletion(conflicting);
 		waitForCompletion(transferTo);
@@ -148,12 +148,12 @@ public class Bug_311756 extends AbstractJobManagerTest {
 					blocked[0] = CLEARED;
 			}
 		};
-		final TestBarrier barrier = new TestBarrier(TestBarrier.STATUS_START);
+		final TestBarrier2 barrier = new TestBarrier2(TestBarrier2.STATUS_START);
 		IdentityRule rule = new IdentityRule();
 		Job conflicting = new Job("Conflicting") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				barrier.setStatus(TestBarrier.STATUS_RUNNING);
+				barrier.setStatus(TestBarrier2.STATUS_RUNNING);
 				try {
 					Thread.sleep(100);
 				} catch (InterruptedException e) {
@@ -168,7 +168,7 @@ public class Bug_311756 extends AbstractJobManagerTest {
 		conflicting.setRule(rule);
 		conflicting.schedule();
 
-		barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 		try {
 			Job.getJobManager().beginRule(rule, null);
 			try {
@@ -203,12 +203,12 @@ public class Bug_311756 extends AbstractJobManagerTest {
 					blocked[0] = CLEARED;
 			}
 		};
-		final TestBarrier barrier = new TestBarrier(TestBarrier.STATUS_START);
+		final TestBarrier2 barrier = new TestBarrier2(TestBarrier2.STATUS_START);
 		IdentityRule rule = new IdentityRule();
 		Job conflicting = new Job("Conflicting") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				barrier.setStatus(TestBarrier.STATUS_RUNNING);
+				barrier.setStatus(TestBarrier2.STATUS_RUNNING);
 				try {
 					Thread.sleep(100);
 				} catch (InterruptedException e) {
@@ -223,7 +223,7 @@ public class Bug_311756 extends AbstractJobManagerTest {
 		conflicting.setRule(rule);
 		conflicting.schedule();
 
-		barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 		Job.getJobManager().beginRule(rule, null);
 		Job.getJobManager().transferRule(rule, conflicting.getThread());
 		try {

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_311863.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_311863.java
@@ -15,7 +15,7 @@ package org.eclipse.core.tests.runtime.jobs;
 
 import org.eclipse.core.runtime.jobs.ILock;
 import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.core.tests.harness.TestBarrier;
+import org.eclipse.core.tests.harness.TestBarrier2;
 
 /**
  * Regression test for bug 311863
@@ -38,10 +38,10 @@ public class Bug_311863 extends AbstractJobManagerTest {
 	 * yields and sleeps
 	 */
 	class TestThread extends Thread {
-		private final TestBarrier tb;
+		private final TestBarrier2 tb;
 		private final int yield_time;
 
-		public TestThread(TestBarrier tb, int yield_time) {
+		public TestThread(TestBarrier2 tb, int yield_time) {
 			this.tb = tb;
 			this.yield_time = yield_time;
 		}
@@ -86,9 +86,9 @@ public class Bug_311863 extends AbstractJobManagerTest {
 	 * @throws Exception
 	 */
 	public void testInterruptDuringLockRelease() throws Exception {
-		final TestBarrier tb1 = new TestBarrier(-1);
-		final TestBarrier tb2 = new TestBarrier(-1);
-		final TestBarrier tb3 = new TestBarrier(-1);
+		final TestBarrier2 tb1 = new TestBarrier2(-1);
+		final TestBarrier2 tb2 = new TestBarrier2(-1);
+		final TestBarrier2 tb3 = new TestBarrier2(-1);
 
 		// The threads that will fight over the lock
 		Thread t1 = new TestThread(tb1, 1);

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_316839.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/Bug_316839.java
@@ -17,7 +17,7 @@ package org.eclipse.core.tests.runtime.jobs;
 import org.eclipse.core.internal.jobs.JobManager;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.*;
-import org.eclipse.core.tests.harness.TestBarrier;
+import org.eclipse.core.tests.harness.TestBarrier2;
 
 /**
  * Regression test for bug 316839.
@@ -26,7 +26,7 @@ public class Bug_316839 extends AbstractJobManagerTest {
 
 	ILock LOCK = Job.getJobManager().newLock();
 
-	TestBarrier barrier = new TestBarrier(TestBarrier.STATUS_WAIT_FOR_START);
+	TestBarrier2 barrier = new TestBarrier2(TestBarrier2.STATUS_WAIT_FOR_START);
 
 	YieldingTestJob yieldingJob;
 	TestJob interruptingJob;
@@ -47,10 +47,10 @@ public class Bug_316839 extends AbstractJobManagerTest {
 				lockGraphWasEmpty = ((JobManager) Job.getJobManager()).getLockManager().isEmpty();
 			}
 		});
-		barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 		interruptingJob.schedule();
 		//let the yielding job perform its yield
-		barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+		barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 
 		// wait for job to complete or for max time...
 		waitForCompletion(yieldingJob);
@@ -84,8 +84,8 @@ public class Bug_316839 extends AbstractJobManagerTest {
 		protected IStatus run(IProgressMonitor monitor) {
 			getJobManager().beginRule(rule, monitor);
 			try {
-				barrier.setStatus(TestBarrier.STATUS_RUNNING);
-				barrier.waitForStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+				barrier.setStatus(TestBarrier2.STATUS_RUNNING);
+				barrier.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 				// Call to some dependent code that causes a yieldRule().
 				// For example, the various routines of ModelManagerImpl
 				// that get and return a shared model. If another thread /

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/DeadlockDetectionTest.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/DeadlockDetectionTest.java
@@ -16,12 +16,14 @@ package org.eclipse.core.tests.runtime.jobs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import org.eclipse.core.internal.jobs.*;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.*;
 import org.eclipse.core.tests.harness.FussyProgressMonitor;
-import org.eclipse.core.tests.harness.TestBarrier;
+import org.eclipse.core.tests.harness.TestBarrier2;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -148,20 +150,21 @@ public class DeadlockDetectionTest {
 	public void testRuleLockInteraction() {
 		final ILock lock = manager.newLock();
 		final ISchedulingRule rule = new IdentityRule();
-		final int[] status = {TestBarrier.STATUS_WAIT_FOR_START, TestBarrier.STATUS_WAIT_FOR_START};
+		final AtomicIntegerArray status = new AtomicIntegerArray(
+				new int[] { TestBarrier2.STATUS_WAIT_FOR_START, TestBarrier2.STATUS_WAIT_FOR_START });
 
 		Thread first = new Thread("Test1") {
 			@Override
 			public void run() {
 				lock.acquire();
-				status[0] = TestBarrier.STATUS_START;
+				status.set(0, TestBarrier2.STATUS_START);
 				assertTrue("1.0", getLockManager().isLockOwner());
-				TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_RUNNING);
+				TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 				manager.beginRule(rule, null);
 				assertTrue("2.0", getLockManager().isLockOwner());
 				manager.endRule(rule);
 				lock.release();
-				status[0] = TestBarrier.STATUS_DONE;
+				status.set(0, TestBarrier2.STATUS_DONE);
 			}
 		};
 
@@ -169,28 +172,28 @@ public class DeadlockDetectionTest {
 			@Override
 			public void run() {
 				manager.beginRule(rule, null);
-				status[1] = TestBarrier.STATUS_START;
+				status.set(1, TestBarrier2.STATUS_START);
 				assertTrue("1.0", getLockManager().isLockOwner());
-				TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_RUNNING);
+				TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_RUNNING);
 				lock.acquire();
 				assertTrue("2.0", getLockManager().isLockOwner());
 				lock.release();
 				manager.endRule(rule);
-				status[1] = TestBarrier.STATUS_DONE;
+				status.set(1, TestBarrier2.STATUS_DONE);
 			}
 		};
 
 		first.start();
 		second.start();
 
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_START);
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_START);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_START);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_START);
 
-		status[0] = TestBarrier.STATUS_RUNNING;
-		status[1] = TestBarrier.STATUS_RUNNING;
+		status.set(0, TestBarrier2.STATUS_RUNNING);
+		status.set(1, TestBarrier2.STATUS_RUNNING);
 
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_DONE);
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_DONE);
 		waitForThreadDeath(first);
 		waitForThreadDeath(second);
 		assertTrue("3.0", !first.isAlive());
@@ -206,7 +209,8 @@ public class DeadlockDetectionTest {
 	 */
 	@Test
 	public void testJobRuleLockInteraction() {
-		final int[] status = {TestBarrier.STATUS_WAIT_FOR_START, TestBarrier.STATUS_WAIT_FOR_START};
+		final AtomicIntegerArray status = new AtomicIntegerArray(
+				new int[] { TestBarrier2.STATUS_WAIT_FOR_START, TestBarrier2.STATUS_WAIT_FOR_START });
 		final ISchedulingRule rule1 = new IdentityRule();
 		final ISchedulingRule rule2 = new IdentityRule();
 		final ILock lock = manager.newLock();
@@ -217,13 +221,13 @@ public class DeadlockDetectionTest {
 				try {
 					assertTrue("1.0", getLockManager().isLockOwner());
 					monitor.beginTask("Testing", 1);
-					status[0] = TestBarrier.STATUS_START;
+					status.set(0, TestBarrier2.STATUS_START);
 					lock.acquire();
-					TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_RUNNING);
+					TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 					assertTrue("2.0", getLockManager().isLockOwner());
 					lock.release();
 					monitor.worked(1);
-					status[0] = TestBarrier.STATUS_DONE;
+					status.set(0, TestBarrier2.STATUS_DONE);
 				} finally {
 					monitor.done();
 				}
@@ -237,13 +241,13 @@ public class DeadlockDetectionTest {
 				try {
 					assertTrue("1.0", getLockManager().isLockOwner());
 					monitor.beginTask("Testing", 1);
-					status[1] = TestBarrier.STATUS_START;
+					status.set(1, TestBarrier2.STATUS_START);
 					lock.acquire();
-					TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_RUNNING);
+					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_RUNNING);
 					assertTrue("2.0", getLockManager().isLockOwner());
 					lock.release();
 					monitor.worked(1);
-					status[1] = TestBarrier.STATUS_DONE;
+					status.set(1, TestBarrier2.STATUS_DONE);
 				} finally {
 					monitor.done();
 				}
@@ -256,14 +260,14 @@ public class DeadlockDetectionTest {
 		first.schedule();
 		second.schedule();
 
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_START);
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_START);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_START);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_START);
 
-		status[0] = TestBarrier.STATUS_RUNNING;
-		status[1] = TestBarrier.STATUS_RUNNING;
+		status.set(0, TestBarrier2.STATUS_RUNNING);
+		status.set(1, TestBarrier2.STATUS_RUNNING);
 
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_DONE);
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_DONE);
 		waitForCompletion(first);
 		waitForCompletion(second);
 
@@ -275,14 +279,20 @@ public class DeadlockDetectionTest {
 		assertTrue("Jobs not removed from graph.", getLockManager().isEmpty());
 	}
 
+	public static void fill(AtomicIntegerArray a, int val) {
+		for (int i = 0, len = a.length(); i < len; i++) {
+			a.set(i, val);
+		}
+	}
+
 	/**
 	 * Regression test for bug 46894. Stale entries left over in graph.
 	 */
 	@Test
 	public void testRuleHierarchyWaitReplace() {
 		final int NUM_JOBS = 3;
-		final int[] status = new int[NUM_JOBS];
-		Arrays.fill(status, TestBarrier.STATUS_WAIT_FOR_START);
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[NUM_JOBS]);
+		fill(status, TestBarrier2.STATUS_WAIT_FOR_START);
 		final ISchedulingRule[] rules = {new PathRule("/testRuleHierarchyWaitReplace"), new PathRule("/testRuleHierarchyWaitReplace/B"), new PathRule("/testRuleHierarchyWaitReplace/C")};
 		final ILock[] locks = {manager.newLock(), manager.newLock()};
 		Job[] jobs = new Job[NUM_JOBS];
@@ -293,8 +303,8 @@ public class DeadlockDetectionTest {
 				try {
 					monitor.beginTask("Testing", 1);
 					manager.beginRule(rules[0], null);
-					status[0] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_RUNNING);
+					status.set(0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[0]);
 					monitor.worked(1);
 				} finally {
@@ -310,12 +320,12 @@ public class DeadlockDetectionTest {
 				try {
 					monitor.beginTask("Testing", 1);
 					locks[0].acquire();
-					TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[1], new TestBlockingMonitor(status, 1));
-					status[1] = TestBarrier.STATUS_WAIT_FOR_RUN;
+					status.set(1, TestBarrier2.STATUS_WAIT_FOR_RUN);
 					locks[1].acquire();
 					locks[1].release();
-					TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_RUNNING);
+					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[1]);
 					locks[0].release();
 					monitor.worked(1);
@@ -332,10 +342,10 @@ public class DeadlockDetectionTest {
 				try {
 					monitor.beginTask("Testing", 1);
 					locks[1].acquire();
-					TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[2], new TestBlockingMonitor(status, 2));
-					status[2] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_RUNNING);
+					status.set(2, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[2]);
 					locks[1].release();
 					monitor.worked(1);
@@ -350,29 +360,29 @@ public class DeadlockDetectionTest {
 			job.schedule();
 		}
 		//wait until the first job starts
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		//now let the second job start
-		status[1] = TestBarrier.STATUS_START;
+		status.set(1, TestBarrier2.STATUS_START);
 		//wait until it blocks on the beginRule call
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_BLOCKED);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_BLOCKED);
 
 		//let the third job start, and wait until it too blocks
-		status[2] = TestBarrier.STATUS_START;
+		status.set(2, TestBarrier2.STATUS_START);
 		//wait until it blocks on the beginRule call
-		TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_BLOCKED);
+		TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_BLOCKED);
 
 		//end the first job
-		status[0] = TestBarrier.STATUS_RUNNING;
+		status.set(0, TestBarrier2.STATUS_RUNNING);
 
 		//wait until the second job gets the rule
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		//let the job finish
-		status[1] = TestBarrier.STATUS_RUNNING;
+		status.set(1, TestBarrier2.STATUS_RUNNING);
 
 		//now wait until the third job gets the rule
-		TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		//let the job finish
-		status[2] = TestBarrier.STATUS_RUNNING;
+		status.set(2, TestBarrier2.STATUS_RUNNING);
 
 		for (Job job : jobs) {
 			waitForCompletion(job);
@@ -392,8 +402,8 @@ public class DeadlockDetectionTest {
 	@Test
 	public void testDetectDeadlock() {
 		final int NUM_JOBS = 3;
-		final int[] status = new int[NUM_JOBS];
-		Arrays.fill(status, TestBarrier.STATUS_WAIT_FOR_START);
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[NUM_JOBS]);
+		fill(status, TestBarrier2.STATUS_WAIT_FOR_START);
 		final ISchedulingRule[] rules = {new PathRule("/testDetectDeadlock"), new PathRule("/testDetectDeadlock/B"), new PathRule("/testDetectDeadlock/C")};
 		final ILock lock = manager.newLock();
 		Job[] jobs = new Job[NUM_JOBS];
@@ -404,8 +414,8 @@ public class DeadlockDetectionTest {
 				try {
 					monitor.beginTask("Testing", 1);
 					manager.beginRule(rules[1], null);
-					status[0] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_RUNNING);
+					status.set(0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[1]);
 					monitor.worked(1);
 				} finally {
@@ -421,10 +431,10 @@ public class DeadlockDetectionTest {
 				try {
 					monitor.beginTask("Testing", 1);
 					lock.acquire();
-					TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[0], new TestBlockingMonitor(status, 1));
-					status[1] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_RUNNING);
+					status.set(1, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[0]);
 					lock.release();
 					monitor.worked(1);
@@ -440,10 +450,10 @@ public class DeadlockDetectionTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					monitor.beginTask("Testing", 1);
-					TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[2], null);
-					status[2] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_RUNNING);
+					status.set(2, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_RUNNING);
 					lock.acquire();
 					lock.release();
 					manager.endRule(rules[2]);
@@ -459,26 +469,26 @@ public class DeadlockDetectionTest {
 			job.schedule();
 		}
 		//wait until the first job starts
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		//now let the third job start
-		status[2] = TestBarrier.STATUS_START;
+		status.set(2, TestBarrier2.STATUS_START);
 		//wait until it gets the rule
-		TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_WAIT_FOR_RUN);
 
 		//let the second job start
-		status[1] = TestBarrier.STATUS_START;
+		status.set(1, TestBarrier2.STATUS_START);
 		//wait until it blocks on the beginRule call
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_BLOCKED);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_BLOCKED);
 
 		//let the third job try for the lock
-		status[2] = TestBarrier.STATUS_RUNNING;
+		status.set(2, TestBarrier2.STATUS_RUNNING);
 		//end the first job
-		status[0] = TestBarrier.STATUS_RUNNING;
+		status.set(0, TestBarrier2.STATUS_RUNNING);
 
 		//wait until the second job gets the rule
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		//let the job finish
-		status[1] = TestBarrier.STATUS_RUNNING;
+		status.set(1, TestBarrier2.STATUS_RUNNING);
 		//wait until all jobs are done
 		for (Job job : jobs) {
 			waitForCompletion(job);
@@ -498,8 +508,8 @@ public class DeadlockDetectionTest {
 	@Test
 	public void testMultipleColumnRemoval() {
 		final int NUM_JOBS = 3;
-		final int[] status = new int[NUM_JOBS];
-		Arrays.fill(status, TestBarrier.STATUS_WAIT_FOR_START);
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[NUM_JOBS]);
+		fill(status, TestBarrier2.STATUS_WAIT_FOR_START);
 		final ISchedulingRule[] rules = {new PathRule("/testMultipleColumnRemoval"), new PathRule("/testMultipleColumnRemoval/B"), new PathRule("/testMultipleColumnRemoval/C")};
 		final IProgressMonitor first = new TestBlockingMonitor(status, 1);
 		final IProgressMonitor second = new TestBlockingMonitor(status, 2);
@@ -511,8 +521,8 @@ public class DeadlockDetectionTest {
 				try {
 					monitor.beginTask("Testing", 1);
 					manager.beginRule(rules[0], null);
-					status[0] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_RUNNING);
+					status.set(0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[0]);
 					monitor.worked(1);
 				} finally {
@@ -527,11 +537,11 @@ public class DeadlockDetectionTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					monitor.beginTask("Testing", 1);
-					TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[1], first);
 					monitor.worked(1);
 				} finally {
-					status[1] = TestBarrier.STATUS_DONE;
+					status.set(1, TestBarrier2.STATUS_DONE);
 					manager.endRule(rules[1]);
 					monitor.done();
 				}
@@ -544,11 +554,11 @@ public class DeadlockDetectionTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					monitor.beginTask("Testing", 1);
-					TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[2], second);
 					monitor.worked(1);
 				} finally {
-					status[2] = TestBarrier.STATUS_DONE;
+					status.set(2, TestBarrier2.STATUS_DONE);
 					manager.endRule(rules[2]);
 					monitor.done();
 				}
@@ -560,24 +570,24 @@ public class DeadlockDetectionTest {
 			job.schedule();
 		}
 		//wait until the first job starts
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		//now let the other two jobs start
-		status[1] = TestBarrier.STATUS_START;
-		status[2] = TestBarrier.STATUS_START;
+		status.set(1, TestBarrier2.STATUS_START);
+		status.set(2, TestBarrier2.STATUS_START);
 		//wait until both are blocked on the beginRule call
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_BLOCKED);
-		TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_BLOCKED);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_BLOCKED);
+		TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_BLOCKED);
 
 		//cancel the blocked jobs
 		first.setCanceled(true);
 		second.setCanceled(true);
 
 		//wait until both jobs are done
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_DONE);
-		TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_DONE);
 
 		//end the first job
-		status[0] = TestBarrier.STATUS_RUNNING;
+		status.set(0, TestBarrier2.STATUS_RUNNING);
 		//wait until all jobs are done
 		for (Job job : jobs) {
 			waitForCompletion(job);
@@ -595,21 +605,22 @@ public class DeadlockDetectionTest {
 		final ISchedulingRule rule1 = new PathRule("/testBeginRuleCancelAfterWait");
 		final ISchedulingRule rule2 = new PathRule("/testBeginRuleCancelAfterWait/B");
 
-		final int[] status = {TestBarrier.STATUS_WAIT_FOR_START, TestBarrier.STATUS_WAIT_FOR_START};
+		final AtomicIntegerArray status = new AtomicIntegerArray(
+				new int[] { TestBarrier2.STATUS_WAIT_FOR_START, TestBarrier2.STATUS_WAIT_FOR_START });
 		final IProgressMonitor canceller = new FussyProgressMonitor();
 
 		Job ruleOwner = new Job("Test1") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
-					status[0] = TestBarrier.STATUS_START;
+					status.set(0, TestBarrier2.STATUS_START);
 					manager.beginRule(rule1, null);
-					TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_RUNNING);
+					TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rule1);
 					monitor.worked(1);
 				} finally {
 					monitor.done();
-					status[0] = TestBarrier.STATUS_DONE;
+					status.set(0, TestBarrier2.STATUS_DONE);
 				}
 				return Status.OK_STATUS;
 			}
@@ -619,20 +630,20 @@ public class DeadlockDetectionTest {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
-					status[1] = TestBarrier.STATUS_RUNNING;
+					status.set(1, TestBarrier2.STATUS_RUNNING);
 					manager.beginRule(rule2, canceller);
 					monitor.worked(1);
 				} finally {
 					manager.endRule(rule2);
 					monitor.done();
-					status[1] = TestBarrier.STATUS_DONE;
+					status.set(1, TestBarrier2.STATUS_DONE);
 				}
 				return Status.OK_STATUS;
 			}
 		};
 
 		ruleOwner.schedule();
-		TestBarrier.waitForStatus(status, TestBarrier.STATUS_START);
+		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_START);
 
 		//schedule a job that is going to begin a conflicting rule and then cancel the wait
 		ruleWait.schedule();
@@ -644,11 +655,11 @@ public class DeadlockDetectionTest {
 		//cancel the wait for the rule
 		canceller.setCanceled(true);
 		//wait until the job completes
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_DONE);
 
 		//let the first job finish
-		status[0] = TestBarrier.STATUS_RUNNING;
-		TestBarrier.waitForStatus(status, TestBarrier.STATUS_DONE);
+		status.set(0, TestBarrier2.STATUS_RUNNING);
+		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_DONE);
 		waitForCompletion(ruleOwner);
 		//the underlying graph should now be empty
 		assertTrue("Canceled rule not removed from graph.", getLockManager().isEmpty());
@@ -660,8 +671,8 @@ public class DeadlockDetectionTest {
 	@Test
 	public void testImplicitRules() {
 		final int NUM_JOBS = 4;
-		final int[] status = new int[NUM_JOBS];
-		Arrays.fill(status, TestBarrier.STATUS_WAIT_FOR_START);
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[NUM_JOBS]);
+		fill(status, TestBarrier2.STATUS_WAIT_FOR_START);
 		final ISchedulingRule[] rules = {new PathRule("/testImplicitRules"), new PathRule("/testImplicitRules/B"), new PathRule("/testImplicitRules/C"), new PathRule("/testImplicitRules/B/D")};
 		Job[] jobs = new Job[NUM_JOBS];
 
@@ -671,8 +682,8 @@ public class DeadlockDetectionTest {
 				try {
 					monitor.beginTask("Testing", 1);
 					manager.beginRule(rules[3], null);
-					status[0] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_RUNNING);
+					status.set(0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[3]);
 					monitor.worked(1);
 				} finally {
@@ -688,8 +699,8 @@ public class DeadlockDetectionTest {
 				try {
 					monitor.beginTask("Testing", 1);
 					manager.beginRule(rules[2], null);
-					status[1] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_RUNNING);
+					status.set(1, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[2]);
 					monitor.worked(1);
 				} finally {
@@ -704,10 +715,10 @@ public class DeadlockDetectionTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					monitor.beginTask("Testing", 1);
-					TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[0], new TestBlockingMonitor(status, 2));
-					status[2] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_RUNNING);
+					status.set(2, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[0]);
 					monitor.worked(1);
 				} finally {
@@ -722,10 +733,10 @@ public class DeadlockDetectionTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					monitor.beginTask("Testing", 1);
-					TestBarrier.waitForStatus(status, 3, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 3, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[1], new TestBlockingMonitor(status, 3));
-					status[3] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 3, TestBarrier.STATUS_RUNNING);
+					status.set(3, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 3, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[1]);
 					monitor.worked(1);
 				} finally {
@@ -739,35 +750,35 @@ public class DeadlockDetectionTest {
 			job.schedule();
 		}
 		//wait until the first 2 jobs start
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_WAIT_FOR_RUN);
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		//now let the third job start
-		status[2] = TestBarrier.STATUS_START;
+		status.set(2, TestBarrier2.STATUS_START);
 		//wait until it blocks on the beginRule call
-		TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_BLOCKED);
+		TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_BLOCKED);
 
 		//let the fourth job start
-		status[3] = TestBarrier.STATUS_START;
+		status.set(3, TestBarrier2.STATUS_START);
 		//wait until it blocks on the beginRule call
-		TestBarrier.waitForStatus(status, 3, TestBarrier.STATUS_BLOCKED);
+		TestBarrier2.waitForStatus(status, 3, TestBarrier2.STATUS_BLOCKED);
 
 		//end the first 2 jobs
-		status[0] = TestBarrier.STATUS_RUNNING;
-		status[1] = TestBarrier.STATUS_RUNNING;
+		status.set(0, TestBarrier2.STATUS_RUNNING);
+		status.set(1, TestBarrier2.STATUS_RUNNING);
 
 		//the third and fourth jobs will now compete in non-deterministic order
 		int runningCount = 0;
 		long waitStart = AbstractJobTest.now();
 		while (runningCount < 2) {
-			if (status[2] == TestBarrier.STATUS_WAIT_FOR_RUN) {
+			if (status.get(2) == TestBarrier2.STATUS_WAIT_FOR_RUN) {
 				//the third job got the rule - let it finish
 				runningCount++;
-				status[2] = TestBarrier.STATUS_RUNNING;
+				status.set(2, TestBarrier2.STATUS_RUNNING);
 			}
-			if (status[3] == TestBarrier.STATUS_WAIT_FOR_RUN) {
+			if (status.get(3) == TestBarrier2.STATUS_WAIT_FOR_RUN) {
 				//the fourth job got the rule - let it finish
 				runningCount++;
-				status[3] = TestBarrier.STATUS_RUNNING;
+				status.set(3, TestBarrier2.STATUS_RUNNING);
 			}
 			//timeout if the two jobs don't start within a reasonable time
 			long elapsed = AbstractJobTest.now() - waitStart;
@@ -791,8 +802,8 @@ public class DeadlockDetectionTest {
 	 */
 	public void _testRuleHierarchyLockInteraction() {
 		final int NUM_JOBS = 5;
-		final int[] status = new int[NUM_JOBS];
-		Arrays.fill(status, TestBarrier.STATUS_WAIT_FOR_START);
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[NUM_JOBS]);
+		fill(status, TestBarrier2.STATUS_WAIT_FOR_START);
 		final ISchedulingRule[] rules = {new PathRule("/A"), new PathRule("/A/B"), new PathRule("/A/C")};
 		Job[] jobs = new Job[NUM_JOBS];
 
@@ -802,8 +813,8 @@ public class DeadlockDetectionTest {
 				try {
 					monitor.beginTask("Testing", 1);
 					manager.beginRule(rules[1], null);
-					status[0] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_RUNNING);
+					status.set(0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[1]);
 					monitor.worked(1);
 				} finally {
@@ -818,10 +829,10 @@ public class DeadlockDetectionTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					monitor.beginTask("Testing", 1);
-					TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[2], null);
-					status[1] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_RUNNING);
+					status.set(1, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[2]);
 					monitor.worked(1);
 				} finally {
@@ -836,10 +847,10 @@ public class DeadlockDetectionTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					monitor.beginTask("Testing", 1);
-					TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[0], new TestBlockingMonitor(status, 2));
-					status[2] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_RUNNING);
+					status.set(2, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[0]);
 					monitor.worked(1);
 				} finally {
@@ -854,10 +865,10 @@ public class DeadlockDetectionTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					monitor.beginTask("Testing", 1);
-					TestBarrier.waitForStatus(status, 3, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 3, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[2], new TestBlockingMonitor(status, 3));
-					status[3] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 3, TestBarrier.STATUS_RUNNING);
+					status.set(3, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 3, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[2]);
 					monitor.worked(1);
 				} finally {
@@ -872,10 +883,10 @@ public class DeadlockDetectionTest {
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					monitor.beginTask("Testing", 1);
-					TestBarrier.waitForStatus(status, 4, TestBarrier.STATUS_START);
+					TestBarrier2.waitForStatus(status, 4, TestBarrier2.STATUS_START);
 					manager.beginRule(rules[2], new TestBlockingMonitor(status, 4));
-					status[4] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 4, TestBarrier.STATUS_RUNNING);
+					status.set(4, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 4, TestBarrier2.STATUS_RUNNING);
 					manager.endRule(rules[2]);
 					monitor.worked(1);
 				} finally {
@@ -889,44 +900,44 @@ public class DeadlockDetectionTest {
 			job.schedule();
 		}
 		//wait until the first job starts
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		//now let the second job start
-		status[1] = TestBarrier.STATUS_START;
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_WAIT_FOR_RUN);
+		status.set(1, TestBarrier2.STATUS_START);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_WAIT_FOR_RUN);
 
 		//let the third job register the wait
-		status[2] = TestBarrier.STATUS_START;
+		status.set(2, TestBarrier2.STATUS_START);
 		//wait until the job is blocked on the scheduling rule
-		TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_BLOCKED);
+		TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_BLOCKED);
 
 		//let the fourth job register the wait
-		status[3] = TestBarrier.STATUS_START;
+		status.set(3, TestBarrier2.STATUS_START);
 		//wait until the job is blocked on the scheduling rule
-		TestBarrier.waitForStatus(status, 3, TestBarrier.STATUS_BLOCKED);
+		TestBarrier2.waitForStatus(status, 3, TestBarrier2.STATUS_BLOCKED);
 
 		//end the first job, and the second job
-		status[0] = TestBarrier.STATUS_RUNNING;
-		status[1] = TestBarrier.STATUS_RUNNING;
+		status.set(0, TestBarrier2.STATUS_RUNNING);
+		status.set(1, TestBarrier2.STATUS_RUNNING);
 
 		//wait until the third job gets the rule
-		TestBarrier.waitForStatus(status, 2, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 2, TestBarrier2.STATUS_WAIT_FOR_RUN);
 
 		//let the fifth job start its wait
-		status[4] = TestBarrier.STATUS_START;
-		TestBarrier.waitForStatus(status, 4, TestBarrier.STATUS_BLOCKED);
+		status.set(4, TestBarrier2.STATUS_START);
+		TestBarrier2.waitForStatus(status, 4, TestBarrier2.STATUS_BLOCKED);
 
 		//let the third job finish
-		status[2] = TestBarrier.STATUS_RUNNING;
+		status.set(2, TestBarrier2.STATUS_RUNNING);
 
 		//wait until the fourth job gets the rule
-		TestBarrier.waitForStatus(status, 3, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 3, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		//let the fourth job end
-		status[3] = TestBarrier.STATUS_RUNNING;
+		status.set(3, TestBarrier2.STATUS_RUNNING);
 
 		//wait until the fifth job gets the rule
-		TestBarrier.waitForStatus(status, 4, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 4, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		//let the fifth job end
-		status[4] = TestBarrier.STATUS_RUNNING;
+		status.set(4, TestBarrier2.STATUS_RUNNING);
 
 		for (Job job : jobs) {
 			waitForCompletion(job);
@@ -1000,7 +1011,7 @@ public class DeadlockDetectionTest {
 	 */
 	public void _testComplexRuleLockInteraction() {
 		final int NUM_LOCKS = 5;
-		final int[] status = {TestBarrier.STATUS_WAIT_FOR_START};
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { TestBarrier2.STATUS_WAIT_FOR_START });
 		final ISchedulingRule[] rules = {new PathRule("/A"), new PathRule("/A/B"), new PathRule("/A/C"), new PathRule("/A/B/D"), new PathRule("/A/C/E")};
 		final ILock[] locks = {manager.newLock(), manager.newLock(), manager.newLock(), manager.newLock(), manager.newLock()};
 		Job[] jobs = new Job[NUM_LOCKS * 3];
@@ -1012,7 +1023,7 @@ public class DeadlockDetectionTest {
 				protected IStatus run(IProgressMonitor monitor) {
 					try {
 						monitor.beginTask("Testing", IProgressMonitor.UNKNOWN);
-						while (status[0] != TestBarrier.STATUS_DONE) {
+						while (status.get(0) != TestBarrier2.STATUS_DONE) {
 							int indexRule = random.nextInt(NUM_LOCKS);
 							int indexLock = random.nextInt(NUM_LOCKS);
 							int secondIndex = random.nextInt(NUM_LOCKS);
@@ -1052,7 +1063,7 @@ public class DeadlockDetectionTest {
 			//ignore
 		}
 
-		status[0] = TestBarrier.STATUS_DONE;
+		status.set(0, TestBarrier2.STATUS_DONE);
 
 		for (Job job : jobs) {
 			int j = 0;
@@ -1080,19 +1091,19 @@ public class DeadlockDetectionTest {
 	 */
 	public void _testJobRuleCancellation() {
 		final ISchedulingRule rule = new IdentityRule();
-		final int[] status = {TestBarrier.STATUS_WAIT_FOR_START};
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { TestBarrier2.STATUS_WAIT_FOR_START });
 
 		Job first = new Job("Test1") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					assertTrue("1.0", getLockManager().isLockOwner());
-					status[0] = TestBarrier.STATUS_START;
-					TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_RUNNING);
+					status.set(0, TestBarrier2.STATUS_START);
+					TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 					monitor.worked(1);
 				} finally {
 					monitor.done();
-					status[0] = TestBarrier.STATUS_DONE;
+					status.set(0, TestBarrier2.STATUS_DONE);
 				}
 				return Status.OK_STATUS;
 			}
@@ -1115,7 +1126,7 @@ public class DeadlockDetectionTest {
 		second.setRule(rule);
 
 		first.schedule();
-		TestBarrier.waitForStatus(status, TestBarrier.STATUS_START);
+		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_START);
 
 		//schedule a job with the same rule and then cancel it
 		second.schedule();
@@ -1125,8 +1136,8 @@ public class DeadlockDetectionTest {
 			//ignore
 		}
 		second.cancel();
-		status[0] = TestBarrier.STATUS_RUNNING;
-		TestBarrier.waitForStatus(status, TestBarrier.STATUS_DONE);
+		status.set(0, TestBarrier2.STATUS_RUNNING);
+		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_DONE);
 		waitForCompletion(first);
 		//the underlying graph should now be empty
 		assertTrue("Canceled job not removed from graph.", getLockManager().isEmpty());
@@ -1139,15 +1150,16 @@ public class DeadlockDetectionTest {
 	public void _testLockMultipleAcquireThenSuspend() {
 		final ISchedulingRule rule = new IdentityRule();
 		final ILock lock = manager.newLock();
-		final int[] status = {TestBarrier.STATUS_WAIT_FOR_START, TestBarrier.STATUS_WAIT_FOR_START};
+		final AtomicIntegerArray status = new AtomicIntegerArray(
+				new int[] { TestBarrier2.STATUS_WAIT_FOR_START, TestBarrier2.STATUS_WAIT_FOR_START });
 
 		Job first = new Job("Test1") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
 				try {
 					manager.beginRule(rule, null);
-					status[0] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_START);
+					status.set(0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_START);
 					lock.acquire();
 					lock.release();
 					manager.endRule(rule);
@@ -1167,13 +1179,13 @@ public class DeadlockDetectionTest {
 					lock.acquire();
 					lock.acquire();
 					lock.acquire();
-					status[1] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_START);
+					status.set(1, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_START);
 					manager.beginRule(rule, null);
 					manager.endRule(rule);
 					lock.release();
-					status[1] = TestBarrier.STATUS_WAIT_FOR_RUN;
-					TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_RUNNING);
+					status.set(1, TestBarrier2.STATUS_WAIT_FOR_RUN);
+					TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_RUNNING);
 					lock.release();
 					lock.release();
 					lock.release();
@@ -1188,21 +1200,21 @@ public class DeadlockDetectionTest {
 		first.schedule();
 		second.schedule();
 		//wait until one gets a rule, and the other acquires a lock
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_WAIT_FOR_RUN);
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_WAIT_FOR_RUN);
 
 		//let the deadlock happen
-		status[0] = TestBarrier.STATUS_START;
-		status[1] = TestBarrier.STATUS_START;
+		status.set(0, TestBarrier2.STATUS_START);
+		status.set(1, TestBarrier2.STATUS_START);
 
 		//wait until it is resolved and the second job releases the lock once
-		TestBarrier.waitForStatus(status, 1, TestBarrier.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 1, TestBarrier2.STATUS_WAIT_FOR_RUN);
 
 		//the underlying graph should not be empty yet
 		assertTrue("Held lock removed from graph.", !getLockManager().isEmpty());
 
 		//wait until the jobs are done
-		status[1] = TestBarrier.STATUS_RUNNING;
+		status.set(1, TestBarrier2.STATUS_RUNNING);
 		waitForCompletion(first);
 		waitForCompletion(second);
 		//the underlying graph should now be empty

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
@@ -1167,7 +1167,9 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		long endTime = now();
 
 		assertEquals("2.0", TestBarrier2.STATUS_DONE, status.get(0));
-		assertTrue("2.1", endTime > startTime);
+		assertTrue("2.1", endTime >= startTime); // XXX this tests makes no sense. now() is guaranteed to be >= anyway.
+													// and the expectation is that it takes NO time anyway... see next
+													// comment
 
 		//the join call should take no actual time (join call should not block thread at all)
 		if (PEDANTIC) {

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/IJobManagerTest.java
@@ -15,6 +15,7 @@ package org.eclipse.core.tests.runtime.jobs;
 
 import java.util.*;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import junit.framework.AssertionFailedError;
 import org.eclipse.core.runtime.*;
 import org.eclipse.core.runtime.jobs.*;
@@ -137,11 +138,11 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	}
 
 	public void testBadGlobalListener() {
-		final int[] status = new int[] {-1};
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { -1 });
 		Job job = new Job("testBadGlobalListener") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				status[0] = TestBarrier.STATUS_RUNNING;
+				status.set(0, TestBarrier2.STATUS_RUNNING);
 				return Status.OK_STATUS;
 			}
 		};
@@ -154,18 +155,18 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		try {
 			Job.getJobManager().addJobChangeListener(listener);
 			job.schedule();
-			TestBarrier.waitForStatus(status, TestBarrier.STATUS_RUNNING);
+			TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_RUNNING);
 		} finally {
 			Job.getJobManager().removeJobChangeListener(listener);
 		}
 	}
 
 	public void testBadLocalListener() {
-		final int[] status = new int[] {-1};
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[] { -1 });
 		Job job = new Job("testBadLocalListener") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				status[0] = TestBarrier.STATUS_RUNNING;
+				status.set(0, TestBarrier2.STATUS_RUNNING);
 				return Status.OK_STATUS;
 			}
 		};
@@ -178,7 +179,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		try {
 			job.addJobChangeListener(listener);
 			job.schedule();
-			TestBarrier.waitForStatus(status, TestBarrier.STATUS_RUNNING);
+			TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_RUNNING);
 		} finally {
 			job.removeJobChangeListener(listener);
 		}
@@ -822,8 +823,8 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 
 	public void testJobFamilyJoin() {
 		//test the join method on a family of jobs
-		final int[] status = new int[1];
-		status[0] = TestBarrier.STATUS_WAIT_FOR_START;
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
+		status.set(0, TestBarrier2.STATUS_WAIT_FOR_START);
 		final int NUM_JOBS = 20;
 		Job[] jobs = new Job[NUM_JOBS];
 		//create two different families of jobs
@@ -847,31 +848,31 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		}
 
 		Thread t = new Thread(() -> {
-			status[0] = TestBarrier.STATUS_START;
+			status.set(0, TestBarrier2.STATUS_START);
 			try {
-				TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_WAIT_FOR_RUN);
-				status[0] = TestBarrier.STATUS_RUNNING;
+				TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+				status.set(0, TestBarrier2.STATUS_RUNNING);
 				manager.join(first, null);
 			} catch (OperationCanceledException | InterruptedException e) {
 				// ignore
 			}
-			status[0] = TestBarrier.STATUS_DONE;
+			status.set(0, TestBarrier2.STATUS_DONE);
 		});
 
 		//start the thread that will join the first family of jobs and be blocked until they finish execution
 		t.start();
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_START);
-		status[0] = TestBarrier.STATUS_WAIT_FOR_RUN;
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_START);
+		status.set(0, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		//wake up the first family of jobs
 		manager.wakeUp(first);
 
 		int i = 0;
 		for (; i < 100; i++) {
-			int currentStatus = status[0];
+			int currentStatus = status.get(0);
 			Job[] result = manager.find(first);
 
 			//if the thread is complete then all jobs must be done
-			if (currentStatus == TestBarrier.STATUS_DONE) {
+			if (currentStatus == TestBarrier2.STATUS_DONE) {
 				assertEquals("2." + i, 0, result.length);
 				break;
 			}
@@ -891,8 +892,8 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 
 	public void testJobFamilyJoinCancelJobs() {
 		//test the join method on a family of jobs, then cancel the jobs that are blocking the join call
-		final int[] status = new int[1];
-		status[0] = TestBarrier.STATUS_WAIT_FOR_START;
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
+		status.set(0, TestBarrier2.STATUS_WAIT_FOR_START);
 		final int NUM_JOBS = 20;
 		TestJob[] jobs = new TestJob[NUM_JOBS];
 		//create two different families of jobs
@@ -915,32 +916,32 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		}
 
 		Thread t = new Thread(() -> {
-			status[0] = TestBarrier.STATUS_START;
+			status.set(0, TestBarrier2.STATUS_START);
 			try {
-				TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_WAIT_FOR_RUN);
-				status[0] = TestBarrier.STATUS_RUNNING;
+				TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+				status.set(0, TestBarrier2.STATUS_RUNNING);
 				manager.join(first, null);
 			} catch (OperationCanceledException | InterruptedException e) {
 				// ignore
 			}
-			status[0] = TestBarrier.STATUS_DONE;
+			status.set(0, TestBarrier2.STATUS_DONE);
 		});
 
 		//start the thread that will join the first family of jobs
 		//it will be blocked until the all jobs in the first family finish execution or are canceled
 		t.start();
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_START);
-		status[0] = TestBarrier.STATUS_WAIT_FOR_RUN;
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_START);
+		status.set(0, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		waitForStart(jobs[0]);
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_RUNNING);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 
 		assertState("2.0", jobs[0], Job.RUNNING);
-		assertEquals("2.1", TestBarrier.STATUS_RUNNING, status[0]);
+		assertEquals("2.1", TestBarrier2.STATUS_RUNNING, status.get(0));
 
 		//cancel the first family of jobs
 		//the join call should be unblocked when all the jobs are canceled
 		manager.cancel(first);
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_DONE);
 
 		//all jobs in the first family should be removed from the manager
 		assertEquals("2.2", 0, manager.find(first).length);
@@ -957,8 +958,8 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 
 	public void testJobFamilyJoinCancelManager() {
 		//test the join method on a family of jobs, then cancel the call
-		final int[] status = new int[1];
-		status[0] = TestBarrier.STATUS_WAIT_FOR_START;
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
+		status.set(0, TestBarrier2.STATUS_WAIT_FOR_START);
 		final int NUM_JOBS = 20;
 		TestJob[] jobs = new TestJob[NUM_JOBS];
 		//create a progress monitor to cancel the join call
@@ -983,35 +984,35 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		}
 
 		Thread t = new Thread(() -> {
-			status[0] = TestBarrier.STATUS_START;
+			status.set(0, TestBarrier2.STATUS_START);
 			try {
-				TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_WAIT_FOR_RUN);
-				status[0] = TestBarrier.STATUS_RUNNING;
+				TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+				status.set(0, TestBarrier2.STATUS_RUNNING);
 				manager.join(first, canceller);
 			} catch (OperationCanceledException | InterruptedException e) {
 				// ignore
 			}
-			status[0] = TestBarrier.STATUS_DONE;
+			status.set(0, TestBarrier2.STATUS_DONE);
 		});
 
 		//start the thread that will join the first family of jobs
 		//it will be blocked until the cancel call is made to the thread
 		t.start();
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_START);
-		status[0] = TestBarrier.STATUS_WAIT_FOR_RUN;
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_START);
+		status.set(0, TestBarrier2.STATUS_WAIT_FOR_RUN);
 		waitForStart(jobs[0]);
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_RUNNING);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_RUNNING);
 
 		assertState("2.0", jobs[0], Job.RUNNING);
-		assertEquals("2.1", TestBarrier.STATUS_RUNNING, status[0]);
+		assertEquals("2.1", TestBarrier2.STATUS_RUNNING, status.get(0));
 
 		//cancel the monitor that is attached to the join call
 		canceller.setCanceled(true);
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_DONE);
 
 		//the first job in the first family should still be running
 		assertState("2.2", jobs[0], Job.RUNNING);
-		assertEquals("2.3", TestBarrier.STATUS_DONE, status[0]);
+		assertEquals("2.3", TestBarrier2.STATUS_DONE, status.get(0));
 		assertTrue("2.4", manager.find(first).length > 0);
 
 		//cancel the second family of jobs
@@ -1116,8 +1117,8 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	 */
 	public void testJobFamilyJoinSimple() {
 		//test the join method on a family of jobs that is empty
-		final int[] status = new int[1];
-		status[0] = TestBarrier.STATUS_WAIT_FOR_START;
+		final AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
+		status.set(0, TestBarrier2.STATUS_WAIT_FOR_START);
 		final int NUM_JOBS = 20;
 		TestJob[] jobs = new TestJob[NUM_JOBS];
 		//create three different families of jobs
@@ -1141,15 +1142,15 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		}
 
 		Thread t = new Thread(() -> {
-			status[0] = TestBarrier.STATUS_START;
+			status.set(0, TestBarrier2.STATUS_START);
 			try {
-				TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_WAIT_FOR_RUN);
-				status[0] = TestBarrier.STATUS_RUNNING;
+				TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+				status.set(0, TestBarrier2.STATUS_RUNNING);
 				manager.join(third, null);
 			} catch (OperationCanceledException | InterruptedException e) {
 				// ignore
 			}
-			status[0] = TestBarrier.STATUS_DONE;
+			status.set(0, TestBarrier2.STATUS_DONE);
 		});
 
 		//try joining the third family of jobs, which is empty
@@ -1158,14 +1159,14 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		t.start();
 
 		//let the thread execute the join call
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_START);
-		assertEquals("1.0", TestBarrier.STATUS_START, status[0]);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_START);
+		assertEquals("1.0", TestBarrier2.STATUS_START, status.get(0));
 		long startTime = now();
-		status[0] = TestBarrier.STATUS_WAIT_FOR_RUN;
-		TestBarrier.waitForStatus(status, 0, TestBarrier.STATUS_DONE);
+		status.set(0, TestBarrier2.STATUS_WAIT_FOR_RUN);
+		TestBarrier2.waitForStatus(status, 0, TestBarrier2.STATUS_DONE);
 		long endTime = now();
 
-		assertEquals("2.0", TestBarrier.STATUS_DONE, status[0]);
+		assertEquals("2.0", TestBarrier2.STATUS_DONE, status.get(0));
 		assertTrue("2.1", endTime > startTime);
 
 		//the join call should take no actual time (join call should not block thread at all)
@@ -1194,21 +1195,21 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	public void testJobFamilyJoinWhenSuspended_1() throws InterruptedException {
 		final Object family = new TestJobFamily(TestJobFamily.TYPE_ONE);
 		final int[] familyJobsCount = new int[] {-1};
-		final TestBarrier barrier = new TestBarrier();
+		final TestBarrier2 barrier = new TestBarrier2();
 		final Job waiting = new FamilyTestJob("waiting job", 1000000, 10, TestJobFamily.TYPE_ONE);
 		final Job running = new FamilyTestJob("running job", 200, 10, TestJobFamily.TYPE_ONE);
 		final IJobChangeListener listener = new JobChangeAdapter() {
 			@Override
 			public void done(IJobChangeEvent event) {
 				if (event.getJob() == running) {
-					barrier.waitForStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+					barrier.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 				}
 			}
 
 			@Override
 			public void running(IJobChangeEvent event) {
 				if (event.getJob() == running) {
-					barrier.setStatus(TestBarrier.STATUS_RUNNING);
+					barrier.setStatus(TestBarrier2.STATUS_RUNNING);
 				}
 			}
 		};
@@ -1219,7 +1220,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 					manager.addJobChangeListener(listener);
 					running.schedule();
 					// wait until running job is actually running
-					barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+					barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 					manager.setLockListener(new LockListener() {
 						private boolean scheduled = false;
 
@@ -1228,7 +1229,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 							// aboutToWait will be called when main job will start joining the running job
 							if (!scheduled) {
 								waiting.schedule();
-								barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+								barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 							}
 							return super.aboutToWait(lockOwner);
 						}
@@ -1237,7 +1238,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 					manager.suspend();
 					manager.join(family, null);
 					familyJobsCount[0] = manager.find(family).length;
-					barrier.setStatus(TestBarrier.STATUS_DONE);
+					barrier.setStatus(TestBarrier2.STATUS_DONE);
 				} catch (InterruptedException e) {
 					// ignore
 				} finally {
@@ -1259,7 +1260,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		};
 		try {
 			job.schedule();
-			barrier.waitForStatus(TestBarrier.STATUS_DONE);
+			barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 			assertEquals(1, familyJobsCount[0]);
 		} catch (AssertionFailedError e) {
 			// interrupt to avoid deadlock and perform cleanup
@@ -1281,21 +1282,21 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	public void testJobFamilyJoinWhenSuspended_2() throws InterruptedException {
 		final Object family = new TestJobFamily(TestJobFamily.TYPE_ONE);
 		final int[] familyJobsCount = new int[] {-1};
-		final TestBarrier barrier = new TestBarrier();
+		final TestBarrier2 barrier = new TestBarrier2();
 		final Job waiting = new FamilyTestJob("waiting job", 1000000, 10, TestJobFamily.TYPE_ONE);
 		final Job running = new FamilyTestJob("running job", 200, 10, TestJobFamily.TYPE_ONE);
 		final IJobChangeListener listener = new JobChangeAdapter() {
 			@Override
 			public void done(IJobChangeEvent event) {
 				if (event.getJob() == running) {
-					barrier.waitForStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+					barrier.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 				}
 			}
 
 			@Override
 			public void running(IJobChangeEvent event) {
 				if (event.getJob() == running) {
-					barrier.setStatus(TestBarrier.STATUS_RUNNING);
+					barrier.setStatus(TestBarrier2.STATUS_RUNNING);
 				}
 			}
 		};
@@ -1306,7 +1307,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 					manager.addJobChangeListener(listener);
 					running.schedule();
 					// wait until running job is actually running
-					barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+					barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 					manager.setLockListener(new LockListener() {
 						private boolean scheduled = false;
 
@@ -1317,14 +1318,14 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 								// suspend before scheduling new job
 								getJobManager().suspend();
 								waiting.schedule();
-								barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+								barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 							}
 							return super.aboutToWait(lockOwner);
 						}
 					});
 					manager.join(family, null);
 					familyJobsCount[0] = manager.find(family).length;
-					barrier.setStatus(TestBarrier.STATUS_DONE);
+					barrier.setStatus(TestBarrier2.STATUS_DONE);
 				} catch (InterruptedException e) {
 					// ignore
 				} finally {
@@ -1346,7 +1347,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		};
 		try {
 			job.schedule();
-			barrier.waitForStatus(TestBarrier.STATUS_DONE);
+			barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 			assertEquals(1, familyJobsCount[0]);
 		} catch (AssertionFailedError e) {
 			// interrupt to avoid deadlock and perform cleanup
@@ -1368,23 +1369,23 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	 */
 	public void testJobFamilyJoinWhenSuspended_3() throws InterruptedException {
 		final Object family = new TestJobFamily(TestJobFamily.TYPE_ONE);
-		final TestBarrier barrier = new TestBarrier();
+		final TestBarrier2 barrier = new TestBarrier2();
 		final Job waiting = new FamilyTestJob("waiting job", 400, 10, TestJobFamily.TYPE_ONE);
 		final Job running = new FamilyTestJob("running job", 200, 10, TestJobFamily.TYPE_ONE);
 		final IJobChangeListener listener = new JobChangeAdapter() {
 			@Override
 			public void done(IJobChangeEvent event) {
 				if (event.getJob() == running) {
-					barrier.waitForStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+					barrier.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 				}
 			}
 
 			@Override
 			public void running(IJobChangeEvent event) {
 				if (event.getJob() == running) {
-					barrier.setStatus(TestBarrier.STATUS_RUNNING);
+					barrier.setStatus(TestBarrier2.STATUS_RUNNING);
 				} else if (event.getJob() == waiting) {
-					barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+					barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 				}
 			}
 		};
@@ -1392,7 +1393,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 			manager.addJobChangeListener(listener);
 			running.schedule();
 			// wait until the running job is actually running
-			barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+			barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 			manager.setLockListener(new LockListener() {
 				private boolean scheduled = false;
 
@@ -1969,20 +1970,20 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		manager.suspend(rule1, null);
 
 		//start a job that acquires a child rule
-		TestBarrier barrier = new TestBarrier();
+		TestBarrier2 barrier = new TestBarrier2();
 		JobRuleRunner runner = new JobRuleRunner("TestSuspendJob", rule2, barrier, 1, true);
 		runner.schedule();
-		barrier.waitForStatus(TestBarrier.STATUS_START);
+		barrier.waitForStatus(TestBarrier2.STATUS_START);
 		//let the job start the rule
-		barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_RUN);
-		barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+		barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_RUN);
+		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 
 		//now try to resume the rule in this thread
 		manager.resume(rule1);
 
 		//finally let the test runner resume the rule
-		barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
-		barrier.waitForStatus(TestBarrier.STATUS_DONE);
+		barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
+		barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 		waitForCompletion(runner);
 
 	}
@@ -2011,25 +2012,25 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		assertNull("1.0", job.getResult());
 
 		//should be able to run a thread that begins the rule
-		int[] status = new int[1];
+		AtomicIntegerArray status = new AtomicIntegerArray(new int[1]);
 		SimpleRuleRunner runner = new SimpleRuleRunner(rule1, status, null);
 		new Thread(runner).start();
-		TestBarrier.waitForStatus(status, TestBarrier.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_DONE);
 
 		//should be able to run a thread that begins a conflicting rule
-		status[0] = 0;
+		status.set(0, 0);
 		runner = new SimpleRuleRunner(rule2, status, null);
 		new Thread(runner).start();
-		TestBarrier.waitForStatus(status, TestBarrier.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_DONE);
 
 		//now begin the rule in this thread
 		manager.beginRule(rule1, null);
 
 		//should still be able to run a thread that begins the rule
-		status[0] = 0;
+		status.set(0, 0);
 		runner = new SimpleRuleRunner(rule1, status, null);
 		new Thread(runner).start();
-		TestBarrier.waitForStatus(status, TestBarrier.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_DONE);
 
 		//our job should still not have executed
 		sleep(100);
@@ -2041,10 +2042,10 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		assertNull("1.2", job.getResult());
 
 		//should still be able to run a thread that begins the rule
-		status[0] = 0;
+		status.set(0, 0);
 		runner = new SimpleRuleRunner(rule1, status, null);
 		new Thread(runner).start();
-		TestBarrier.waitForStatus(status, TestBarrier.STATUS_DONE);
+		TestBarrier2.waitForStatus(status, TestBarrier2.STATUS_DONE);
 
 		//finally resume the rule in this thread
 		manager.resume(rule1);
@@ -2079,15 +2080,15 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 			}
 			//TODO This test is failing
 			//can't transfer a rule when the destination already owns an unrelated rule
-			TestBarrier barrier = new TestBarrier();
+			TestBarrier2 barrier = new TestBarrier2();
 			ISchedulingRule unrelatedRule = new PathRule("UnrelatedRule");
 			JobRuleRunner ruleRunner = new JobRuleRunner("testTransferFailure", unrelatedRule, barrier, 1, false);
 			ruleRunner.schedule();
 			//wait for runner to start
-			barrier.waitForStatus(TestBarrier.STATUS_START);
+			barrier.waitForStatus(TestBarrier2.STATUS_START);
 			//let it acquire the rule
-			barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_RUN);
-			barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+			barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_RUN);
+			barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 			//transferring the calling thread's rule to the background job should fail
 			//because the destination thread already owns a rule
 			try {
@@ -2097,8 +2098,8 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 				//expected
 			}
 			//let the background job finish
-			barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
-			barrier.waitForStatus(TestBarrier.STATUS_DONE);
+			barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
+			barrier.waitForStatus(TestBarrier2.STATUS_DONE);
 			try {
 				ruleRunner.join();
 			} catch (InterruptedException e1) {
@@ -2114,13 +2115,13 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	 */
 	public void testTransferJobToJob() {
 		final PathRule ruleToTransfer = new PathRule("testTransferJobToJob");
-		final TestBarrier barrier = new TestBarrier();
+		final TestBarrier2 barrier = new TestBarrier2();
 		final Thread[] sourceThread = new Thread[1];
 		final Job destination = new Job("testTransferJobToJob.destination") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				barrier.setStatus(TestBarrier.STATUS_RUNNING);
-				barrier.waitForStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+				barrier.setStatus(TestBarrier2.STATUS_RUNNING);
+				barrier.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 				return Status.OK_STATUS;
 			}
 		};
@@ -2130,7 +2131,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 				sourceThread[0] = Thread.currentThread();
 				//schedule the destination job and wait until it is running
 				destination.schedule();
-				barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+				barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 				IJobManagerTest.this.sleep(100);
 
 				//transferring the rule will fail because it must have been acquired by beginRule
@@ -2146,7 +2147,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		assertTrue("1.1", source.getResult().getException() instanceof RuntimeException);
 
 		//let the destination finish
-		barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+		barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 		waitForCompletion(destination);
 		if (!destination.getResult().isOK()) {
 			fail("1.2", destination.getResult().getException());
@@ -2211,16 +2212,16 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	 */
 	public void testTransferToJob() {
 		final PathRule rule = new PathRule("testTransferToJob");
-		final TestBarrier barrier = new TestBarrier();
-		barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_START);
+		final TestBarrier2 barrier = new TestBarrier2();
+		barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_START);
 		final Exception[] failure = new Exception[1];
 		final Thread testThread = Thread.currentThread();
 		//create a job that the rule will be transferred to
 		Job job = new Job("testTransferSimple") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				barrier.setStatus(TestBarrier.STATUS_RUNNING);
-				barrier.waitForStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+				barrier.setStatus(TestBarrier2.STATUS_RUNNING);
+				barrier.waitForStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 
 				//sleep a little to ensure the test thread is waiting
 				IJobManagerTest.this.sleep(100);
@@ -2236,14 +2237,14 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 		};
 		job.schedule();
 		//wait until the job starts
-		barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 
 		//now begin and transfer the rule
 		manager.beginRule(rule, null);
 		manager.transferRule(rule, job.getThread());
 
 		//kick the job to allow it to transfer the rule back
-		barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_DONE);
+		barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_DONE);
 
 		//try to begin the rule again, which will block until the rule is transferred back
 		manager.beginRule(rule, null);
@@ -2267,15 +2268,15 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	 */
 	public void testTransferToJobWaitingOnChildRule() {
 		final PathRule rule = new PathRule("testTransferToJobWaitingOnChildRule");
-		final TestBarrier barrier = new TestBarrier();
-		barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_START);
+		final TestBarrier2 barrier = new TestBarrier2();
+		barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_START);
 		final Exception[] failure = new Exception[1];
 		final Thread testThread = Thread.currentThread();
 		//create a job that the rule will be transferred to
 		Job job = new Job("testTransferToJobWaitingOnChildRule") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				barrier.setStatus(TestBarrier.STATUS_RUNNING);
+				barrier.setStatus(TestBarrier2.STATUS_RUNNING);
 				//this will block until the rule is transferred
 				PathRule child = new PathRule(rule.getFullPath().append("child"));
 				try {
@@ -2297,7 +2298,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 
 		job.schedule();
 		//wait until the job starts
-		barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 		//wait a bit longer to ensure the job is blocked
 		try {
 			Thread.sleep(100);
@@ -2326,15 +2327,15 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 	 */
 	public void testTransferToWaitingJob() {
 		final PathRule rule = new PathRule("testTransferToWaitingJob");
-		final TestBarrier barrier = new TestBarrier();
-		barrier.setStatus(TestBarrier.STATUS_WAIT_FOR_START);
+		final TestBarrier2 barrier = new TestBarrier2();
+		barrier.setStatus(TestBarrier2.STATUS_WAIT_FOR_START);
 		final Exception[] failure = new Exception[1];
 		final Thread testThread = Thread.currentThread();
 		//create a job that the rule will be transferred to
 		Job job = new Job("testTransferToWaitingJob") {
 			@Override
 			protected IStatus run(IProgressMonitor monitor) {
-				barrier.setStatus(TestBarrier.STATUS_RUNNING);
+				barrier.setStatus(TestBarrier2.STATUS_RUNNING);
 				//this will block until the rule is transferred
 				try {
 					manager.beginRule(rule, null);
@@ -2355,7 +2356,7 @@ public class IJobManagerTest extends AbstractJobManagerTest {
 
 		job.schedule();
 		//wait until the job starts
-		barrier.waitForStatus(TestBarrier.STATUS_RUNNING);
+		barrier.waitForStatus(TestBarrier2.STATUS_RUNNING);
 		//wait a bit longer to ensure the job is blocked
 		try {
 			Thread.sleep(100);

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/SimpleRuleRunner.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/SimpleRuleRunner.java
@@ -13,10 +13,11 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.jobs.*;
-import org.eclipse.core.tests.harness.TestBarrier;
+import org.eclipse.core.tests.harness.TestBarrier2;
 
 /**
  * This runnable will try to begin the given rule in the Job Manager.  It will
@@ -25,11 +26,11 @@ import org.eclipse.core.tests.harness.TestBarrier;
 class SimpleRuleRunner implements Runnable {
 	private ISchedulingRule rule;
 	private IProgressMonitor monitor;
-	private int[] status;
+	private AtomicIntegerArray status;
 	RuntimeException exception;
 	private static final IJobManager manager = Job.getJobManager();
 
-	public SimpleRuleRunner(ISchedulingRule rule, int[] status, IProgressMonitor monitor) {
+	public SimpleRuleRunner(ISchedulingRule rule, AtomicIntegerArray status, IProgressMonitor monitor) {
 		this.rule = rule;
 		this.monitor = monitor;
 		this.status = status;
@@ -39,7 +40,7 @@ class SimpleRuleRunner implements Runnable {
 	@Override
 	public void run() {
 		//tell the caller that we have entered the run method
-		status[0] = TestBarrier.STATUS_RUNNING;
+		status.set(0, TestBarrier2.STATUS_RUNNING);
 		try {
 			try {
 				manager.beginRule(rule, monitor);
@@ -51,7 +52,7 @@ class SimpleRuleRunner implements Runnable {
 		} catch (RuntimeException e) {
 			exception = e;
 		} finally {
-			status[0] = TestBarrier.STATUS_DONE;
+			status.set(0, TestBarrier2.STATUS_DONE);
 		}
 	}
 }

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/TestBlockingMonitor.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/jobs/TestBlockingMonitor.java
@@ -13,9 +13,10 @@
  *******************************************************************************/
 package org.eclipse.core.tests.runtime.jobs;
 
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.tests.harness.TestBarrier;
+import org.eclipse.core.tests.harness.TestBarrier2;
 import org.eclipse.core.tests.harness.TestProgressMonitor;
 
 /**
@@ -23,14 +24,14 @@ import org.eclipse.core.tests.harness.TestProgressMonitor;
  * becomes blocked.
  */
 class TestBlockingMonitor extends TestProgressMonitor implements IProgressMonitor {
-	private TestBarrier barrier;
+	private TestBarrier2 barrier;
 	private boolean cancelled;
 
-	public TestBlockingMonitor(int[] status, int index) {
-		this(new TestBarrier(status, index));
+	public TestBlockingMonitor(AtomicIntegerArray status, int index) {
+		this(new TestBarrier2(status, index));
 	}
 
-	public TestBlockingMonitor(TestBarrier barrier) {
+	public TestBlockingMonitor(TestBarrier2 barrier) {
 		this.barrier = barrier;
 	}
 
@@ -46,7 +47,7 @@ class TestBlockingMonitor extends TestProgressMonitor implements IProgressMonito
 
 	@Override
 	public void setBlocked(IStatus reason) {
-		barrier.setStatus(TestBarrier.STATUS_BLOCKED);
+		barrier.setStatus(TestBarrier2.STATUS_BLOCKED);
 	}
 
 	@Override


### PR DESCRIPTION
Array elements can not be accessed volatile.
see https://rules.sonarsource.com/java/RSPEC-3077

TestBarrier2 uses AtomicIntegerArray instead.
TestBarrier deprecated (still used in other plugins)
