### PR TITLE
Bug 476404 - Delete Platform authentication API as announced for Eclipse

### DIFF
--- a/bundles/org.eclipse.core.runtime/.settings/.api_filters
+++ b/bundles/org.eclipse.core.runtime/.settings/.api_filters
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.core.runtime" version="2">
+    <resource path="src/org/eclipse/core/runtime/Platform.java" type="org.eclipse.core.runtime.Platform">
+        <filter comment="Planned_removal" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.core.runtime.Platform"/>
+                <message_argument value="addAuthorizationInfo(URL, String, String, Map&lt;String,String&gt;)"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Planned_removal" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.core.runtime.Platform"/>
+                <message_argument value="flushAuthorizationInfo(URL, String, String)"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Planned_removal" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.core.runtime.Platform"/>
+                <message_argument value="getAuthorizationInfo(URL, String, String)"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Planned_removal" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.core.runtime.Platform"/>
+                <message_argument value="getPluginStateLocation(Plugin)"/>
+            </message_arguments>
+        </filter>
+        <filter comment="planned_removal" id="338792546">
+            <message_arguments>
+                <message_argument value="org.eclipse.core.runtime.Platform"/>
+                <message_argument value="getProtectionSpace(URL)"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>

--- a/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
+++ b/bundles/org.eclipse.core.runtime/src/org/eclipse/core/runtime/Platform.java
@@ -493,43 +493,6 @@ public final class Platform {
 	}
 
 	/**
-	 * Adds the given authorization information to the key ring. The
-	 * information is relevant for the specified protection space and the
-	 * given authorization scheme. The protection space is defined by the
-	 * combination of the given server URL and realm. The authorization
-	 * scheme determines what the authorization information contains and how
-	 * it should be used. The authorization information is a <code>Map</code>
-	 * of <code>String</code> to <code>String</code> and typically
-	 * contains information such as user names and passwords.
-	 *
-	 * @param serverUrl the URL identifying the server for this authorization
-	 *		information. For example, "http://www.example.com/".
-	 * @param realm the subsection of the given server to which this
-	 *		authorization information applies.  For example,
-	 *		"realm1@example.com" or "" for no realm.
-	 * @param authScheme the scheme for which this authorization information
-	 *		applies. For example, "Basic" or "" for no authorization scheme
-	 * @param info a <code>Map</code> containing authorization information
-	 *		such as user names and passwords (key type : <code>String</code>,
-	 *		value type : <code>String</code>)
-	 * @exception CoreException if there are problems setting the
-	 *		authorization information. Reasons include:
-	 * <ul>
-	 * <li>The keyring could not be saved.</li>
-	 * </ul>
-	 * @deprecated Authorization database is superseded by the Equinox secure storage.
-	 * Use <code>org.eclipse.equinox.security.storage.SecurePreferencesFactory</code>
-	 * to obtain secure preferences and <code>org.eclipse.equinox.security.storage.ISecurePreferences</code>
-	 * for data access and modifications.
-	 * Consider using <code>ISecurePreferences#put(String, String, boolean)</code> as a replacement of this method.
-	 * This API will be deleted in a future release. See bug 370248 for details.
-	 */
-	@Deprecated
-	public static void addAuthorizationInfo(URL serverUrl, String realm, String authScheme, Map<String,String> info) throws CoreException {
-		AuthorizationHandler.addAuthorizationInfo(serverUrl, realm, authScheme, info);
-	}
-
-	/**
 	 * Adds the given log listener to the notification list of the platform.
 	 * <p>
 	 * Once registered, a listener starts receiving notification as entries
@@ -607,36 +570,6 @@ public final class Platform {
 		InternalPlatform.getDefault().endSplash();
 	}
 
-	/**
-	 * Removes the authorization information for the specified protection
-	 * space and given authorization scheme. The protection space is defined
-	 * by the given server URL and realm.
-	 *
-	 * @param serverUrl the URL identifying the server to remove the
-	 *		authorization information for. For example,
-	 *		"http://www.example.com/".
-	 * @param realm the subsection of the given server to remove the
-	 *		authorization information for. For example,
-	 *		"realm1@example.com" or "" for no realm.
-	 * @param authScheme the scheme for which the authorization information
-	 *		to remove applies. For example, "Basic" or "" for no
-	 *		authorization scheme.
-	 * @exception CoreException if there are problems removing the
-	 *		authorization information. Reasons include:
-	 * <ul>
-	 * <li>The keyring could not be saved.</li>
-	 * </ul>
-	 * @deprecated Authorization database is superseded by the Equinox secure storage.
-	 * Use <code>org.eclipse.equinox.security.storage.SecurePreferencesFactory</code>
-	 * to obtain secure preferences and <code>org.eclipse.equinox.security.storage.ISecurePreferences</code>
-	 * for data access and modifications.
-	 * Consider using <code>ISecurePreferences#clear()</code> as a replacement of this method.
-	 * This API will be deleted in a future release. See bug 370248 for details.
-	 */
-	@Deprecated
-	public static void flushAuthorizationInfo(URL serverUrl, String realm, String authScheme) throws CoreException {
-		AuthorizationHandler.flushAuthorizationInfo(serverUrl, realm, authScheme);
-	}
 
 	/**
 	 * Returns the adapter manager used for extending
@@ -649,33 +582,6 @@ public final class Platform {
 		return InternalPlatform.getDefault().getAdapterManager();
 	}
 
-	/**
-	 * Returns the authorization information for the specified protection
-	 * space and given authorization scheme. The protection space is defined
-	 * by the given server URL and realm. Returns <code>null</code> if no
-	 * such information exists.
-	 *
-	 * @param serverUrl the URL identifying the server for the authorization
-	 *		information. For example, "http://www.example.com/".
-	 * @param realm the subsection of the given server to which the
-	 *		authorization information applies.  For example,
-	 *		"realm1@example.com" or "" for no realm.
-	 * @param authScheme the scheme for which the authorization information
-	 *		applies. For example, "Basic" or "" for no authorization scheme
-	 * @return the authorization information for the specified protection
-	 *		space and given authorization scheme, or <code>null</code> if no
-	 *		such information exists
-	 * @deprecated Authorization database is superseded by the Equinox secure storage.
-	 * Use <code>org.eclipse.equinox.security.storage.SecurePreferencesFactory</code>
-	 * to obtain secure preferences and <code>org.eclipse.equinox.security.storage.ISecurePreferences</code>
-	 * for data access and modifications.
-	 * Consider using <code>ISecurePreferences#get(String, String)</code> as a replacement of this method.
-	 * This API will be deleted in a future release. See bug 370248 for details.
-	 */
-	@Deprecated
-	public static Map<String,String> getAuthorizationInfo(URL serverUrl, String realm, String authScheme) {
-		return AuthorizationHandler.getAuthorizationInfo(serverUrl, realm, authScheme);
-	}
 
 	/**
 	 * Returns the command line args provided to the Eclipse runtime layer when it was first run.
@@ -795,45 +701,6 @@ public final class Platform {
 		return null;
 	}
 
-	/**
-	 * Returns the location in the local file system of the plug-in
-	 * state area for the given plug-in.
-	 * The platform must be running.
-	 * <p>
-	 * The plug-in state area is a file directory within the
-	 * platform's metadata area where a plug-in is free to create files.
-	 * The content and structure of this area is defined by the plug-in,
-	 * and the particular plug-in is solely responsible for any files
-	 * it puts there. It is recommended for plug-in preference settings.
-	 * </p>
-	 *
-	 * @param plugin the plug-in whose state location is returned
-	 * @return a local file system path
-	 * @deprecated clients should call {@link #getStateLocation(Bundle)} instead
-	 */
-	@Deprecated
-	public static IPath getPluginStateLocation(Plugin plugin) {
-		return plugin.getStateLocation();
-	}
-
-	/**
-	 * Returns the protection space (realm) for the specified resource, or
-	 * <code>null</code> if the realm is unknown.
-	 *
-	 * @param resourceUrl the URL of the resource whose protection space is
-	 *		returned. For example, "http://www.example.com/folder/".
-	 * @return the protection space (realm) for the specified resource, or
-	 *		<code>null</code> if the realm is unknown
-	 * @deprecated Authorization database is superseded by the Equinox secure storage.
-	 * Use <code>org.eclipse.equinox.security.storage.SecurePreferencesFactory</code>
-	 * to obtain secure preferences and <code>org.eclipse.equinox.security.storage.ISecurePreferences</code>
-	 * for data access and modifications.
-	 * This API will be deleted in a future release. See bug 370248 for details.
-	 */
-	@Deprecated
-	public static String getProtectionSpace(URL resourceUrl) {
-		return AuthorizationHandler.getProtectionSpace(resourceUrl);
-	}
 
 	/**
 	 * Removes the indicated (identical) log listener from the notification list


### PR DESCRIPTION
4.2.

This was planned for June 2017 !!!! but was post-phoned as CVS still
used it. Time to finally delete it.