### PR TITLE
Bug 516583 - allow session tests to read workspace location

### DIFF
--- a/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/WorkspaceSessionTestSuite.java
+++ b/tests/org.eclipse.core.tests.harness/src/org/eclipse/core/tests/session/WorkspaceSessionTestSuite.java
@@ -79,4 +79,10 @@ public class WorkspaceSessionTestSuite extends SessionTestSuite {
 
 	}
 
+	/**
+	 * @return workspace location
+	 */
+	public IPath getInstanceLocation() {
+		return instanceLocation;
+	}
 }


### PR DESCRIPTION
This is needed for tests that want modify workspace *before* workspace
is started.