### PR TITLE
Delete CONTRIBUTING.md #13

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,0 @@
-Contributing to Platform UI
-===================
-
-Contributions to the Eclipse platform are most welcome. There are many ways to contribute, 
-from entering high quality bug reports, to contributing code or documentation changes. 
-For a complete guide, see the [How to Contribute] [1] page on the team wiki.
-
-[1]: http://wiki.eclipse.org/Platform_UI/How_to_Contribute


### PR DESCRIPTION
Contained links to outdated bugtracker, old git.
Instead the files from the common .github repository 
https://github.com/eclipse-platform/.github
should be shown.