### PR TITLE
Add a method EclipseContextFactory.getServiceContext(Class<?>) method

### DIFF
--- a/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.core.contexts/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-SymbolicName: org.eclipse.e4.core.contexts
-Bundle-Version: 1.9.100.qualifier
+Bundle-Version: 1.10.0.qualifier
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
Currently one needs to pass a BundleContext to
EclipseContextFactory.getServiceContext to get an OSGi Service Context.
In case such one is not at hand, it would be useful to let it determine
it by a context class and adding some sanity checks.

Fix https://github.com/eclipse-platform/eclipse.platform.runtime/issues/43