### PR TITLE
Add OSGi service.prefs bundle to features

### DIFF
--- a/features/org.eclipse.core.runtime.feature/feature.xml
+++ b/features/org.eclipse.core.runtime.feature/feature.xml
@@ -65,4 +65,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.osgi.service.prefs"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
With https://github.com/eclipse-equinox/equinox.bundles/pull/39 the sources of `org.osgi.service.prefs` in `org.eclipse.equinox.preferences` are replaced by the original osgi-bundle.
This change adds that bundle to features that include `org.eclipse.equinox.preferences` to ensure the sources stay available.

This is part of:
https://github.com/eclipse-equinox/equinox.framework/issues/40
