### PR TITLE
Add missing Package-Import of org.osgi.service.prefs

### DIFF
--- a/bundles/org.eclipse.e4.core.di.extensions.supplier/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.core.di.extensions.supplier/META-INF/MANIFEST.MF
@@ -18,6 +18,7 @@ Import-Package: javax.annotation;version="1.3.5",
  org.osgi.service.component.annotations;version="1.3.0";resolution:=optional,
  org.osgi.service.event;version="1.3.0",
  org.osgi.service.log;version="1.3.0",
+ org.osgi.service.prefs;version="[1.1.0,2.0.0)",
  org.osgi.util.tracker;version="1.5.3"
 Service-Component: OSGI-INF/org.eclipse.e4.core.di.internal.extensions.OSGiObjectSupplier.xml,
  OSGI-INF/org.eclipse.e4.core.di.internal.extensions.EventObjectSupplier.xml,


### PR DESCRIPTION
Fix the compilation error in the current I-Build: https://ci.eclipse.org/releng/job/I-build-4.24/96

That failure is due to the replacement of embedded OSGi sources by their 'original' OSGi bundles performed in 
https://github.com/eclipse-equinox/equinox.bundles/pull/39

@tjwatson, @laeubi that's the same scenario like in https://github.com/eclipse-equinox/equinox.bundles/pull/31

