### PR TITLE
Error log on shutdown without stack (Fixes #50)

### DIFF
--- a/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/ImplicitJobs.java
+++ b/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/ImplicitJobs.java
@@ -136,7 +136,7 @@ class ImplicitJobs {
 				return;
 			}
 			String msg = "Worker thread ended job: " + lastJob + ", but still holds rule: " + threadJob; //$NON-NLS-1$ //$NON-NLS-2$
-			error = new Status(IStatus.ERROR, JobManager.PI_JOBS, 1, msg, null);
+			error = new Status(IStatus.ERROR, JobManager.PI_JOBS, 1, msg, new IllegalStateException(msg));
 			//end the thread job
 			endThreadJob(threadJob, false);
 		}


### PR DESCRIPTION
Add stack to the status

Fixes https://github.com/eclipse-platform/eclipse.platform.runtime/issues/50