### PR TITLE
[dogfooding] Apply new dombine declaration OrderedLock

### DIFF
--- a/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/OrderedLock.java
+++ b/bundles/org.eclipse.core.jobs/src/org/eclipse/core/internal/jobs/OrderedLock.java
@@ -98,7 +98,6 @@ public class OrderedLock implements ILock, ISchedulingRule {
 		if (Thread.interrupted())
 			throw new InterruptedException();
 
-		boolean success = false;
 		if (delay <= 0)
 			return attempt();
 		Semaphore semaphore = createSemaphore();
@@ -106,7 +105,7 @@ public class OrderedLock implements ILock, ISchedulingRule {
 			return true;
 		if (DEBUG)
 			System.out.println("[" + Thread.currentThread() + "] Operation waiting to be executed... " + this); //$NON-NLS-1$ //$NON-NLS-2$
-		success = doAcquire(semaphore, delay);
+		boolean success = doAcquire(semaphore, delay);
 		manager.resumeSuspendedLocks(Thread.currentThread());
 		if (DEBUG)
 			System.out.println("[" + Thread.currentThread() + //$NON-NLS-1$


### PR DESCRIPTION
To ensure that new JDT cleanups are stable and work as intended we
should apply them to the Eclipse code base. This change uses the changes
from Bug 572440 on the jdt ui plug-in