### PR TITLE
[dogfooding] Apply new dombine declaration InjectorImpl

### DIFF
--- a/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/InjectorImpl.java
+++ b/bundles/org.eclipse.e4.core.di/src/org/eclipse/e4/core/internal/di/InjectorImpl.java
@@ -723,9 +723,8 @@ public class InjectorImpl implements IInjector {
 		for (Method method : methods) {
 
 			Boolean isOverridden = null;
-			Map<Method, Boolean> methodMap = null;
 			Class<?> originalClass = userObject.getClass();
-			methodMap = isOverriddenCache.get(originalClass);
+			Map<Method, Boolean> methodMap = isOverriddenCache.get(originalClass);
 			if (methodMap != null) {
 				isOverridden = methodMap.get(method);
 			}


### PR DESCRIPTION
To ensure that new JDT cleanups are stable and work as intended we
should apply them to the Eclipse code base. This change uses the changes
from Bug 572440 on the jdt ui plug-in