### PR TITLE
[dogfooding] Apply new dombine declaration ResourceBundleHelper

### DIFF
--- a/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.e4.core.services/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-SymbolicName: org.eclipse.e4.core.services;singleton:=true
 Bundle-Name: %pluginName
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-Version: 2.3.100.qualifier
+Bundle-Version: 2.3.200.qualifier
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Import-Package: javax.annotation;version="1.3.5",

--- a/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/ResourceBundleHelper.java
+++ b/bundles/org.eclipse.e4.core.services/src/org/eclipse/e4/core/internal/services/ResourceBundleHelper.java
@@ -602,7 +602,6 @@ public class ResourceBundleHelper {
 			return defaultLocale;
 		}
 
-		String language = ""; //$NON-NLS-1$
 		String country = ""; //$NON-NLS-1$
 		String variant = ""; //$NON-NLS-1$
 
@@ -618,7 +617,7 @@ public class ResourceBundleHelper {
 			return defaultLocale;
 		}
 
-		language = localeParts[0];
+		String language = localeParts[0];
 
 		if (localeParts.length > 1) {
 			if (!localeParts[1].isEmpty() && !localeParts[1].matches("[a-zA-Z]{2}|[0-9]{3}")) { //$NON-NLS-1$


### PR DESCRIPTION
To ensure that new JDT cleanups are stable and work as intended we
should apply them to the Eclipse code base. This change uses the changes
from Bug 572440 on the jdt ui plug-in