### PR TITLE
WIP: POM and product version changes for 4.25 release

### DIFF
--- a/bundles/org.eclipse.core.jobs/pom.xml
+++ b/bundles/org.eclipse.core.jobs/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.runtime</artifactId>
     <groupId>eclipse.platform.runtime</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 

--- a/tests/org.eclipse.core.contenttype.tests/pom.xml
+++ b/tests/org.eclipse.core.contenttype.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.runtime.tests</artifactId>
     <groupId>eclipse.platform.runtime</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.core</groupId>
   <artifactId>org.eclipse.core.contenttype.tests</artifactId>

--- a/tests/org.eclipse.core.expressions.tests/pom.xml
+++ b/tests/org.eclipse.core.expressions.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.runtime.tests</artifactId>
     <groupId>eclipse.platform.runtime</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.core</groupId>
   <artifactId>org.eclipse.core.expressions.tests</artifactId>

--- a/tests/org.eclipse.core.tests.harness/pom.xml
+++ b/tests/org.eclipse.core.tests.harness/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.runtime.tests</artifactId>
     <groupId>eclipse.platform.runtime</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.core</groupId>
   <artifactId>org.eclipse.core.tests.harness</artifactId>

--- a/tests/org.eclipse.core.tests.runtime/pom.xml
+++ b/tests/org.eclipse.core.tests.runtime/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>eclipse.platform.runtime.tests</artifactId>
     <groupId>eclipse.platform.runtime</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.core</groupId>
   <artifactId>org.eclipse.core.tests.runtime</artifactId>

--- a/tests/org.eclipse.e4.core.tests/pom.xml
+++ b/tests/org.eclipse.e4.core.tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.runtime.tests</artifactId>
     <groupId>eclipse.platform.runtime</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.e4</groupId>
   <artifactId>org.eclipse.e4.core.tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>eclipse.platform.runtime</groupId>
     <artifactId>eclipse.platform.runtime</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <artifactId>eclipse.platform.runtime.tests</artifactId>
   <packaging>pom</packaging>


### PR DESCRIPTION
Tracked in [eclipse.platform.releng.aggregator#290](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/290) and [eclipse.platform.releng.aggregator#291](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/291)

Need to wait to merge until after 4.24 Release