### PR TITLE
Add Platform.getNativeEncoding() API

### DIFF
--- a/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
-Bundle-Version: 3.25.0.qualifier
+Bundle-Version: 3.26.0.qualifier
 Bundle-SymbolicName: org.eclipse.core.runtime; singleton:=true
 Bundle-Vendor: %providerName
 Bundle-Activator: org.eclipse.core.internal.runtime.PlatformActivator

--- a/features/org.eclipse.core.runtime.feature/feature.xml
+++ b/features/org.eclipse.core.runtime.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.core.runtime.feature"
       label="%featureName"
-      version="1.2.1700.qualifier"
+      version="1.3.0.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.core.tests.runtime/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Core Tests Runtime
 Bundle-SymbolicName: org.eclipse.core.tests.runtime; singleton:=true
-Bundle-Version: 3.20.200.qualifier
+Bundle-Version: 3.20.300.qualifier
 Bundle-Activator: org.eclipse.core.tests.runtime.RuntimeTestsPlugin
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.core.tests.internal.preferences,
@@ -12,7 +12,7 @@ Export-Package: org.eclipse.core.tests.internal.preferences,
  org.eclipse.core.tests.runtime.perf
 Require-Bundle: org.junit,
  org.eclipse.test.performance;resolution:=optional,
- org.eclipse.core.runtime;bundle-version="3.19.0",
+ org.eclipse.core.runtime;bundle-version="3.26.0",
  org.eclipse.core.tests.harness;bundle-version="3.11.0",
  org.apiguardian;bundle-version="1.1.2"
 Bundle-ActivationPolicy: lazy

--- a/tests/org.eclipse.core.tests.runtime/pom.xml
+++ b/tests/org.eclipse.core.tests.runtime/pom.xml
@@ -20,7 +20,7 @@
   </parent>
   <groupId>org.eclipse.core</groupId>
   <artifactId>org.eclipse.core.tests.runtime</artifactId>
-  <version>3.20.200-SNAPSHOT</version>
+  <version>3.20.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>

--- a/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PlatformTest.java
+++ b/tests/org.eclipse.core.tests.runtime/src/org/eclipse/core/tests/runtime/PlatformTest.java
@@ -16,6 +16,7 @@ package org.eclipse.core.tests.runtime;
 import static java.util.Collections.emptyMap;
 
 import java.io.*;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.*;
 import java.util.jar.*;
@@ -64,6 +65,20 @@ public class PlatformTest extends RuntimeTest {
 		super.tearDown();
 		logService.setFile(originalLocation, true);
 		RuntimeTestsPlugin.getContext().ungetService(logRef);
+	}
+
+	public void testGetNativeEncoding() {
+		Charset encoding = Platform.getNativeEncoding();
+		assertNotNull(encoding);
+		String vmSpec = System.getProperty("java.vm.specification.version");
+		int version = Integer.parseInt(vmSpec);
+		String property;
+		if (version >= 18) {
+			property = System.getProperty("native.encoding");
+		} else {
+			property = System.getProperty("sun.jnu.encoding");
+		}
+		assertEquals(Charset.forName(property), encoding);
 	}
 
 	public void testGetCommandLine() {


### PR DESCRIPTION
With https://openjdk.java.net/jeps/400 implemented in Java 18,
"file.encoding" system property became meaningless and can't be used
anymore to determine system native encoding.

Unfortunately, that property was widely used in Eclipse API's and was
the standard way to get default system encoding. So both
org.eclipse.ui.WorkbenchEncoding.getWorkbenchDefaultEncoding() and
org.eclipse.core.resources.ResourcesPlugin.getEncoding() were using this
property and need now a proper replacement.

The new API tries first to get the value of the "native.encoding"
property (populated by Java 18), and if not there, uses internal
"sun.jnu.encoding" property (used in all supported Java versions).
In case neither property is set, Charset.defaultCharset() is used as
fallback solution.

See https://github.com/eclipse-platform/eclipse.platform.resources/issues/154